### PR TITLE
Handle smooth control handle editing

### DIFF
--- a/apps/desktop/components/InteractiveScene.tsx
+++ b/apps/desktop/components/InteractiveScene.tsx
@@ -22,6 +22,11 @@ export const InteractiveScene = () => {
       onMouseMove={(e) => {
         activeTool.onMouseMove(e);
       }}
+      onDoubleClick={(e) => {
+        if (!activeTool.onDoubleClick) return;
+
+        activeTool.onDoubleClick(e);
+      }}
     />
   );
 };

--- a/apps/desktop/lib/core/Contour.ts
+++ b/apps/desktop/lib/core/Contour.ts
@@ -46,7 +46,7 @@ export class ContourPoint extends Point implements IContourPoint {
   }
 
   toggleSmooth() {
-    this.#smooth = true;
+    this.#smooth = !this.#smooth;
   }
 }
 

--- a/apps/desktop/lib/editor/Editor.ts
+++ b/apps/desktop/lib/editor/Editor.ts
@@ -247,6 +247,11 @@ export class Editor {
     return this.#scene.addPoint(x, y, pointType);
   }
 
+  // **
+  // Get the neighbor points of a point
+  // @param p - The point to get the neighbors of
+  // @returns The neighbor points of the point
+  // **
   public getNeighborPoints(p: ContourPoint): ContourPoint[] {
     return this.#scene.getNeighborPoints(p);
   }

--- a/apps/desktop/types/tool.ts
+++ b/apps/desktop/types/tool.ts
@@ -13,6 +13,7 @@ export interface Tool {
 
   keyDownHandler?(e: KeyboardEvent): void;
   keyUpHandler?(e: KeyboardEvent): void;
+  onDoubleClick?(e: React.MouseEvent<HTMLCanvasElement>): void;
 
   drawInteractive?(ctx: IRenderer): void;
 }


### PR DESCRIPTION
Double clicking on a corner handle will toggle it to a smooth corner, which means when you draw one control handle, the other will shift such to make both form a straight line. Fixes #8 