### PR TITLE
build: add nix dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,62 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787736819,
+        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1787926460,
+        "narHash": "sha256-Rf2+5+ACRsI0xBicCraxsBtfSaQ93Br0Nr22nWimkS4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "04ceec130b3a935d01584d4b1a68a366919674a9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,74 @@
+{
+  description = "Shift Editor development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { nixpkgs, rust-overlay, ... }:
+    let
+      systems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+    in
+    {
+      devShells = nixpkgs.lib.genAttrs systems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ (import rust-overlay) ];
+          };
+
+          rustToolchainToml = (builtins.fromTOML (builtins.readFile ./rust-toolchain.toml)).toolchain;
+          rustToolchain = pkgs.rust-bin.stable.${rustToolchainToml.channel}.default.override {
+            extensions = rustToolchainToml.components ++ [ "rust-analyzer" ];
+          };
+
+          pnpm = pkgs.writeShellScriptBin "pnpm" ''
+            export COREPACK_ENABLE_DOWNLOAD_PROMPT="0"
+            export COREPACK_HOME="''${COREPACK_HOME:-''${XDG_CACHE_HOME:-$HOME/.cache}/corepack}"
+            exec ${pkgs.nodejs_24}/bin/corepack pnpm "$@"
+          '';
+
+          commonPackages = with pkgs; [
+            cmake
+            git
+            nodejs_24
+            pkg-config
+            pnpm
+            python3
+            rustToolchain
+          ];
+
+          linuxPackages = with pkgs; lib.optionals stdenv.hostPlatform.isLinux [
+            alsa-lib
+            at-spi2-atk
+            cups
+            dbus
+            gtk3
+            nss
+            xorg.libX11
+            xorg.libXScrnSaver
+            xorg.libXtst
+            xorg.libxkbfile
+          ];
+
+          darwinPackages = with pkgs; lib.optionals stdenv.hostPlatform.isDarwin [
+            libiconv
+          ];
+        in
+        {
+          default = pkgs.mkShell {
+            packages = commonPackages ++ linuxPackages ++ darwinPackages;
+
+            shellHook = ''
+              export COREPACK_ENABLE_DOWNLOAD_PROMPT="0"
+              echo "Shift dev shell: node $(node --version), pnpm $(pnpm --version), rustc $(rustc --version)"
+            '';
+          };
+        });
+    };
+}


### PR DESCRIPTION
## Summary

- Add a pinned Nix dev shell for Shift's Node, pnpm, and Rust toolchains.
- Include Linux Electron/native development dependencies and Apple Silicon macOS support.
- Add `.envrc` so direnv users can opt into automatic shell loading with `direnv allow`.

## Issue

Closes #105

## Testing

- `nix flake check --all-systems --no-build`
- `nix develop --command bash -lc 'node -v; pnpm -v; rustc --version'`
- Linux runtime shell entry not tested locally; `x86_64-linux` and `aarch64-linux` dev shell outputs were evaluated by Nix.
