### PR TITLE
test(e2e): make preflight failures actionable

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -83,7 +83,7 @@ When the correct split is unclear, propose the subjects and path groups before s
 2. Inspect `git status`, unstaged and staged diffs, and recent commit subjects.
 3. Identify secrets, generated files, unrelated work, and the logical commit boundaries.
 4. If multiple commits are needed and the user has not already approved the plan, propose the ordered subjects and wait.
-5. Run the focused tests and repository checks appropriate to each change.
+5. Run the focused tests and repository checks appropriate to each change. For desktop user-flow or rendering changes, complete the E2E impact check in `apps/desktop/e2e/README.md`: search existing specs by affected surface, run the smallest relevant Playwright project/file/title filter, inspect intentional snapshot updates, and state any relevant E2E coverage not run.
 6. Stage explicit paths or hunks. Never use `git add .` or `git add -A`.
 7. Commit without bypassing hooks.
 8. Inspect `git status` and the resulting commit after each commit.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -73,6 +73,15 @@ Testing entries must distinguish:
 
 For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
 
+### Desktop E2E impact
+
+For changes that can affect desktop user flows or rendering, complete the E2E impact check in `apps/desktop/e2e/README.md` before opening or updating the pull request.
+
+- Search existing specs by affected surface, command, or workflow even when the branch does not change E2E files.
+- Run the smallest relevant Playwright project, file, and title filter. Run the complete affected project for broad or shared-fixture changes.
+- Update visual snapshots only for intentional appearance changes, inspect every changed image, and rerun without update mode.
+- List exact E2E commands in `## Testing`; explicitly identify relevant E2E coverage not run and why.
+
 ### Issue linkage
 
 Every ordinary pull request includes `## Issue`. Search open and recently closed issues before opening or updating the pull request, and reference every issue materially addressed by the change.

--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -83,7 +83,7 @@ When the correct split is unclear, propose the subjects and path groups before s
 2. Inspect `git status`, unstaged and staged diffs, and recent commit subjects.
 3. Identify secrets, generated files, unrelated work, and the logical commit boundaries.
 4. If multiple commits are needed and the user has not already approved the plan, propose the ordered subjects and wait.
-5. Run the focused tests and repository checks appropriate to each change.
+5. Run the focused tests and repository checks appropriate to each change. For desktop user-flow or rendering changes, complete the E2E impact check in `apps/desktop/e2e/README.md`: search existing specs by affected surface, run the smallest relevant Playwright project/file/title filter, inspect intentional snapshot updates, and state any relevant E2E coverage not run.
 6. Stage explicit paths or hunks. Never use `git add .` or `git add -A`.
 7. Commit without bypassing hooks.
 8. Inspect `git status` and the resulting commit after each commit.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -73,6 +73,15 @@ Testing entries must distinguish:
 
 For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
 
+### Desktop E2E impact
+
+For changes that can affect desktop user flows or rendering, complete the E2E impact check in `apps/desktop/e2e/README.md` before opening or updating the pull request.
+
+- Search existing specs by affected surface, command, or workflow even when the branch does not change E2E files.
+- Run the smallest relevant Playwright project, file, and title filter. Run the complete affected project for broad or shared-fixture changes.
+- Update visual snapshots only for intentional appearance changes, inspect every changed image, and rerun without update mode.
+- List exact E2E commands in `## Testing`; explicitly identify relevant E2E coverage not run and why.
+
 ### Issue linkage
 
 Every ordinary pull request includes `## Issue`. Search open and recently closed issues before opening or updating the pull request, and reference every issue materially addressed by the change.

--- a/.codex/skills/commit/SKILL.md
+++ b/.codex/skills/commit/SKILL.md
@@ -83,7 +83,7 @@ When the correct split is unclear, propose the subjects and path groups before s
 2. Inspect `git status`, unstaged and staged diffs, and recent commit subjects.
 3. Identify secrets, generated files, unrelated work, and the logical commit boundaries.
 4. If multiple commits are needed and the user has not already approved the plan, propose the ordered subjects and wait.
-5. Run the focused tests and repository checks appropriate to each change.
+5. Run the focused tests and repository checks appropriate to each change. For desktop user-flow or rendering changes, complete the E2E impact check in `apps/desktop/e2e/README.md`: search existing specs by affected surface, run the smallest relevant Playwright project/file/title filter, inspect intentional snapshot updates, and state any relevant E2E coverage not run.
 6. Stage explicit paths or hunks. Never use `git add .` or `git add -A`.
 7. Commit without bypassing hooks.
 8. Inspect `git status` and the resulting commit after each commit.

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -73,6 +73,15 @@ Testing entries must distinguish:
 
 For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
 
+### Desktop E2E impact
+
+For changes that can affect desktop user flows or rendering, complete the E2E impact check in `apps/desktop/e2e/README.md` before opening or updating the pull request.
+
+- Search existing specs by affected surface, command, or workflow even when the branch does not change E2E files.
+- Run the smallest relevant Playwright project, file, and title filter. Run the complete affected project for broad or shared-fixture changes.
+- Update visual snapshots only for intentional appearance changes, inspect every changed image, and rerun without update mode.
+- List exact E2E commands in `## Testing`; explicitly identify relevant E2E coverage not run and why.
+
 ### Issue linkage
 
 Every ordinary pull request includes `## Issue`. Search open and recently closed issues before opening or updating the pull request, and reference every issue materially addressed by the change.

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -14,23 +14,42 @@ Run commands from the repository root:
 | `pnpm test:e2e:gpu`           | Run hardware-GPU correctness tests             |
 | `pnpm test:e2e:perf`          | Run Playwright performance measurements        |
 
-Append a Playwright file filter for a focused run:
+Append Playwright file and title filters to run the smallest relevant check:
 
 ```sh
 pnpm test:e2e:visual e2e/home.spec.ts
-pnpm test:e2e:visual e2e/document-recovery.spec.ts
-pnpm test:e2e:gpu e2e/glyph-grid.spec.ts
+pnpm test:e2e:visual e2e/document-recovery.spec.ts --grep "Save As"
+pnpm test:e2e:gpu e2e/glyph-grid.spec.ts --grep "source switching"
 ```
 
-Build the native bridge first with `pnpm build:native` when its binary is absent or stale. Each E2E command builds the Electron main, workspace, preload, and renderer bundles through `build.ts --e2e`.
+Use repeat mode to reproduce a suspected flake without running the rest of the project:
+
+```sh
+pnpm test:e2e:gpu e2e/variable-navigation-glyph-grid.spec.ts \
+  --grep "keeps variable preview" --repeat-each=10
+```
+
+Build the native bridge first with `pnpm build:native` when its binary is absent or stale. Each E2E command builds the Electron main, workspace, preload, and renderer bundles through `build.ts --e2e`; filtering still avoids running unrelated tests.
+
+## E2E impact checks
+
+Before committing a desktop user-flow or rendering change:
+
+1. Search `apps/desktop/e2e/` using the affected surface, command, or workflow name. A production-file change can require an existing E2E test or snapshot update even when no E2E source changed.
+2. Run the matching `visual` spec for interface, interaction, menu, lifecycle, persistence, or software-rendered canvas behavior. Run the matching `gpu` spec for hardware rendering, preview residency, or Grid behavior.
+3. Use a file and `--grep` filter for a narrow change. Run the complete affected project when the change crosses several flows or shared fixture boundaries.
+4. For intentional visual changes, update and inspect the affected snapshots, then rerun the focused visual spec without update mode. The `ci: update visual snapshots` pull-request label can regenerate macOS baselines on the branch when local rendering differs from the hosted runner.
+5. Record the exact E2E commands in the pull request. Explicitly state which relevant project was not run and why.
+
+Do not update snapshots merely to make a failure pass. Inspect the diff and confirm that it represents the intended product change.
 
 ## Projects and fixtures
 
-| Project  | Fixture                   | Rendering                                         | CI policy                            |
-| -------- | ------------------------- | ------------------------------------------------- | ------------------------------------ |
-| `visual` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on pull requests and `main` |
-| `gpu`    | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required on pull requests and `main` |
-| `perf`   | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only              |
+| Project  | Fixture                   | Rendering                                         | CI policy                                 |
+| -------- | ------------------------- | ------------------------------------------------- | ----------------------------------------- |
+| `visual` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required in the merge queue and on `main` |
+| `gpu`    | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required in the merge queue and on `main` |
+| `perf`   | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only                   |
 
 Visual tests default to MutatorSans. Authored GPU and performance tests default to the MutatorSans designspace and accept another editable source through `SHIFT_E2E_FONT_PATH`. Preview residency tests default to MutatorSans TTF through `SHIFT_E2E_PREVIEW_FONT_PATH`; variable preview scrubbing defaults to Host Grotesk through `SHIFT_E2E_VARIABLE_PREVIEW_FONT_PATH`:
 

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -95,12 +95,9 @@ export async function openCatalogGlyph(
   await page.getByPlaceholder("Search glyphs...").fill(glyphName);
   await expect(surface).toHaveAttribute("data-filtered-glyph-count", "1");
   await expect(surface).toHaveAttribute("data-first-glyph-id", glyphId);
-  await page.evaluate(
-    () =>
-      new Promise<void>((resolve) => {
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-      }),
-  );
+  await expect(glyphCatalogCanvas(page)).toHaveAttribute("data-grid-readiness", "Complete", {
+    timeout: 30_000,
+  });
   await clickFirstCatalogGlyph(page);
   await waitForEditorReady(page, glyphId);
 }

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -98,7 +98,7 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
     try {
       await use(testRoot);
     } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true });
+      fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   },
 
@@ -311,7 +311,7 @@ export const recoveryTest = base.extend<{ recoveryApp: RecoveryApp }>({
       });
     } finally {
       if (app) await killApp(app);
-      fs.rmSync(testRoot, { recursive: true, force: true });
+      fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   },
 });

--- a/apps/desktop/e2e/fixtures/perfApp.ts
+++ b/apps/desktop/e2e/fixtures/perfApp.ts
@@ -108,7 +108,12 @@ function createAppTest(fontPath: string, prepareSource: typeof createAuthoredDoc
           childProcess.kill("SIGKILL");
           await exited;
         }
-        fs.rmSync(testRoot, { recursive: true, force: true });
+        fs.rmSync(testRoot, {
+          recursive: true,
+          force: true,
+          maxRetries: 5,
+          retryDelay: 100,
+        });
       }
     },
 

--- a/apps/desktop/e2e/variable-navigation-glyph-grid.spec.ts
+++ b/apps/desktop/e2e/variable-navigation-glyph-grid.spec.ts
@@ -3,6 +3,8 @@ import type { AxisId, GlyphId, GlyphName, NamedInstanceId, SourceId } from "@shi
 import { expect, test } from "./fixtures/perfApp";
 import {
   editorShell,
+  fontNavigation,
+  glyphCatalogCanvas,
   glyphProperties,
   openCatalogGlyph,
   variationControls,
@@ -137,11 +139,17 @@ async function expectPreview(
 test("keeps variable preview and exact-source editability coherent across Grid navigation", async ({
   page,
 }) => {
+  test.slow();
+
   await expect.poll(() => page.evaluate(() => Boolean(navigator.gpu))).toBe(true);
   await expect.poll(() => page.evaluate(() => Boolean(window.shift?.font.loaded))).toBe(true);
   const fixture = await createVariableNavigationFixture(page);
 
-  await page.getByRole("button", { name: "Axes", exact: true }).click();
+  await expect(page).toHaveURL(/#\/home$/);
+  await expect(glyphCatalogCanvas(page)).toHaveAttribute("data-grid-readiness", "Complete", {
+    timeout: 30_000,
+  });
+  await fontNavigation(page).getByRole("button", { name: "Axes", exact: true }).click();
   const axisInput = page.getByLabel("Navigation Weight value", { exact: true });
   await axisInput.click();
   await axisInput.fill("650");


### PR DESCRIPTION
## Summary

- document fast project, file, title, and repeat filters and require desktop E2E impact checks during commits and pull-request preparation
- wait for the resident Grid's explicit readiness state instead of animation-frame timing before catalog interactions
- give the long variable-navigation scenario an appropriate budget and tolerate bounded transient fixture-cleanup contention

## Issue

Closes #302

## Testing

- `pnpm agent-skills:check`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test:e2e:gpu e2e/variable-navigation-glyph-grid.spec.ts --grep "keeps variable preview" --repeat-each=10` — 10/10 passed
- `pnpm test:e2e:visual e2e/landing.spec.ts --grep "creates an editable font" --repeat-each=10` — 10/10 passed
- `pnpm test:e2e:gpu` — 16/16 passed
- `pnpm test:e2e:visual` — failed on seven pre-existing Pen snapshots and the pre-existing source-topology recovery fixture; 88 passed and 1 skipped

## Follow-up

- Refs #303 for layout-independent Pen snapshots
- Refs #304 for the invalid recovery metric fixture
