### PR TITLE
docs: keep execution metadata out of issues and pull requests

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -80,5 +80,6 @@ A request to create or file an issue authorizes the corresponding `gh issue crea
 - Never create a duplicate merely to give a pull request something to close.
 - Never fabricate reproduction steps, logs, acceptance criteria, labels, milestones, or relationships.
 - Never include credentials, signing material, tokens, private paths, or sensitive user documents.
+- Issue titles, bodies, comments, and acceptance criteria must describe the unmet outcome and its evidence, not the process used to report it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the issue. Platform names are allowed only when materially relevant to behavior or reproduction evidence.
 - Never close or reopen an issue without explicit authorization or the approved `Closes #N` merge transition.
 - Never claim that a pull request fully resolves an issue when acceptance criteria remain unmet.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -129,6 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -129,7 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
-- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not the process used to produce it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the change. Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -80,5 +80,6 @@ A request to create or file an issue authorizes the corresponding `gh issue crea
 - Never create a duplicate merely to give a pull request something to close.
 - Never fabricate reproduction steps, logs, acceptance criteria, labels, milestones, or relationships.
 - Never include credentials, signing material, tokens, private paths, or sensitive user documents.
+- Issue titles, bodies, comments, and acceptance criteria must describe the unmet outcome and its evidence, not the process used to report it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the issue. Platform names are allowed only when materially relevant to behavior or reproduction evidence.
 - Never close or reopen an issue without explicit authorization or the approved `Closes #N` merge transition.
 - Never claim that a pull request fully resolves an issue when acceptance criteria remain unmet.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -129,6 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -129,7 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
-- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not the process used to produce it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the change. Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.

--- a/.codex/skills/issue/SKILL.md
+++ b/.codex/skills/issue/SKILL.md
@@ -80,5 +80,6 @@ A request to create or file an issue authorizes the corresponding `gh issue crea
 - Never create a duplicate merely to give a pull request something to close.
 - Never fabricate reproduction steps, logs, acceptance criteria, labels, milestones, or relationships.
 - Never include credentials, signing material, tokens, private paths, or sensitive user documents.
+- Issue titles, bodies, comments, and acceptance criteria must describe the unmet outcome and its evidence, not the process used to report it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the issue. Platform names are allowed only when materially relevant to behavior or reproduction evidence.
 - Never close or reopen an issue without explicit authorization or the approved `Closes #N` merge transition.
 - Never claim that a pull request fully resolves an issue when acceptance criteria remain unmet.

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -129,6 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -129,7 +129,7 @@ When reviewing a pull request:
 - Never open an ordinary pull request without searching for relevant issues and including an issue section.
 - Never open a pull request from a branch with uncommitted intended changes.
 - Never include credentials, signing material, `.env` files, or tokens.
-- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not agent workflow. Never mention agents, handoffs, remote hosts, machine names, tmux sessions, worktrees, or “finishing work off.” Platform names are allowed only when materially relevant to behavior or testing evidence.
+- Pull request titles, bodies, comments, commits, and release-note wording must describe the change and its validation, not the process used to produce it. Never include incidental execution metadata such as agent identity, handoff mechanics, remote hosts, machine names, tmux sessions, worktree paths, or “finishing work off.” Mention such infrastructure only when it is itself the subject of the change. Platform names are allowed only when materially relevant to behavior or testing evidence.
 - Never force-push, merge, enable auto-merge, or publish a release unless the user explicitly asks.
 - Never fabricate issue links, test results, screenshots, reviewers, or release-note claims.
 - Never hide a failed or skipped check from the pull request body.


### PR DESCRIPTION
## Summary

- require issue and pull request content to focus on outcomes, changes, and supporting evidence
- prohibit incidental execution metadata while allowing infrastructure details when they are the subject
- synchronize the canonical guidance across supported client adapters

## Issue

No issue — small documentation hardening for issue and pull request guidance.

## Testing

- `nix develop --command pnpm agent-skills:check`
- pre-commit hooks
