### PR TITLE
build(nix): update dev shell inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1787736819,
-        "narHash": "sha256-cV5xEJJK3BvhU8rEd4mC9UsmDi5qscv/kzGPhBRC5WA=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9fbb54b33e91ee4ca368e35a78e0613c720600b3",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1787926460,
-        "narHash": "sha256-Rf2+5+ACRsI0xBicCraxsBtfSaQ93Br0Nr22nWimkS4=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "04ceec130b3a935d01584d4b1a68a366919674a9",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

- update the Nix flake lock for the dev shell inputs
- verify the Nix dev shell can link the native SQLite dependency used by the Rust workspace

## Issue

No issue — dev-shell maintenance.

## Testing

- `nix develop --command bash -lc 'echo SDKROOT=$SDKROOT; echo LIBRARY_PATH=${LIBRARY_PATH-}; command -v sqlite3 || true; tmp=$(mktemp -d); printf "int main(){return 0;}\\n" > "$tmp/t.c"; cc "$tmp/t.c" -lsqlite3 -o "$tmp/t" && echo sqlite-link-ok || echo sqlite-link-fail'`
- `nix develop --command pnpm build:native`
