### PR TITLE
docs: require the Nix development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,13 @@ export const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>(
 
 This project uses **pnpm** (v11) as its package manager.
 
+## Development Environment
+
+- Run repository commands inside the Nix dev shell defined by `flake.nix`.
+- When `IN_NIX_SHELL` is unset, use `nix develop --command <command>` rather than relying on machine-global Node, pnpm, Rust, Cargo, or native dependencies.
+- Fresh and remote worktrees must not assume direnv has allowed `.envrc`; either launch the agent with `nix develop --command pi` or prefix its repository commands with `nix develop --command`.
+- Do not create Corepack wrappers or install fallback toolchains to work around a missing dev-shell command.
+
 ## Available Commands
 
 ### Development


### PR DESCRIPTION
## Summary

- document the flake dev shell as the authoritative environment for repository commands
- require fresh and remote worktrees to enter the shell explicitly instead of installing fallback toolchains

## Issue

No issue — small repository documentation update.

## Testing

- `nix develop --command git diff --check origin/main...HEAD`
- pre-commit hooks: whitespace, YAML, merge-conflict, large-file, and Oxfmt checks
- E2E not run (documentation-only change)
