### PR TITLE
test(e2e): add cross-platform desktop integration coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,12 @@ jobs:
           - name: GPU
             project: gpu
             runner: macos-latest
+          - name: Platform Windows
+            project: platform
+            runner: windows-latest
+          - name: Platform Linux
+            project: platform
+            runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -483,6 +489,10 @@ jobs:
 
       - name: Install toolchain
         run: rustup show
+
+      - name: Install Linux display environment
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install --yes fluxbox xvfb
 
       - name: Cache node_modules
         uses: actions/cache@v6
@@ -514,13 +524,30 @@ jobs:
         run: pnpm build:native
 
       - name: Run E2E tests
+        if: runner.os != 'Linux'
         run: pnpm test:e2e:${{ matrix.project }}
 
-      - name: Upload Playwright failures
-        if: failure()
+      - name: Run E2E tests with virtual desktop
+        if: runner.os == 'Linux'
+        run: >-
+          xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c
+          'fluxbox >/tmp/shift-fluxbox.log 2>&1 & sleep 1;
+          exec pnpm test:e2e:${{ matrix.project }}'
+
+      - name: Upload platform evidence
+        if: always() && matrix.project == 'platform'
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-${{ matrix.project }}-results
+          name: playwright-${{ matrix.project }}-${{ runner.os }}-results
+          path: apps/desktop/e2e/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Upload Playwright failures
+        if: failure() && matrix.project != 'platform'
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-${{ matrix.project }}-${{ runner.os }}-results
           path: apps/desktop/e2e/test-results/
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,62 +530,33 @@ jobs:
           retention-days: 1
 
   e2e:
-    name: E2E ${{ matrix.name }}
+    name: E2E ${{ matrix.name }} ${{ matrix.shard }}/${{ matrix.shard-total }}
     needs: e2e-build
     strategy:
       fail-fast: false
       matrix:
+        target: [visual, platform-windows, platform-linux]
+        shard: [1, 2, 3]
         include:
-          - name: Visual 1/3
+          - shard-total: 3
+          - target: visual
+            name: Visual
             project: visual
             runner: macos-latest
-            shard: 1/3
-            artifact-suffix: visual-1-of-3
-          - name: Visual 2/3
-            project: visual
-            runner: macos-latest
-            shard: 2/3
-            artifact-suffix: visual-2-of-3
-          - name: Visual 3/3
-            project: visual
-            runner: macos-latest
-            shard: 3/3
-            artifact-suffix: visual-3-of-3
-          - name: GPU
+          - target: platform-windows
+            name: Platform Windows
+            project: platform
+            runner: windows-latest
+          - target: platform-linux
+            name: Platform Linux
+            project: platform
+            runner: ubuntu-latest
+          - target: gpu
+            name: GPU
             project: gpu
             runner: macos-latest
-            shard: 1/1
-            artifact-suffix: gpu
-          - name: Platform Windows 1/3
-            project: platform
-            runner: windows-latest
-            shard: 1/3
-            artifact-suffix: platform-windows-1-of-3
-          - name: Platform Windows 2/3
-            project: platform
-            runner: windows-latest
-            shard: 2/3
-            artifact-suffix: platform-windows-2-of-3
-          - name: Platform Windows 3/3
-            project: platform
-            runner: windows-latest
-            shard: 3/3
-            artifact-suffix: platform-windows-3-of-3
-          - name: Platform Linux 1/3
-            project: platform
-            runner: ubuntu-latest
-            shard: 1/3
-            artifact-suffix: platform-linux-1-of-3
-          - name: Platform Linux 2/3
-            project: platform
-            runner: ubuntu-latest
-            shard: 2/3
-            artifact-suffix: platform-linux-2-of-3
-          - name: Platform Linux 3/3
-            project: platform
-            runner: ubuntu-latest
-            shard: 3/3
-            artifact-suffix: platform-linux-3-of-3
+            shard: 1
+            shard-total: 1
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
@@ -643,7 +614,7 @@ jobs:
         if: always() && matrix.project == 'platform'
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-${{ matrix.artifact-suffix }}-results
+          name: playwright-${{ matrix.target }}-${{ matrix.shard }}-of-${{ matrix.shard-total }}-results
           path: apps/desktop/e2e/test-results/
           if-no-files-found: ignore
           retention-days: 14
@@ -652,7 +623,7 @@ jobs:
         if: failure() && matrix.project != 'platform'
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-${{ matrix.artifact-suffix }}-results
+          name: playwright-${{ matrix.target }}-${{ matrix.shard }}-of-${{ matrix.shard-total }}-results
           path: apps/desktop/e2e/test-results/
           retention-days: 7
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -600,7 +600,7 @@ jobs:
           pnpm --dir apps/desktop exec playwright test
           --project=${{ matrix.project }}
           --fully-parallel
-          --shard=${{ matrix.shard }}
+          --shard=${{ matrix.shard }}/${{ matrix.shard-total }}
 
       - name: Run E2E tests with virtual desktop
         if: runner.os == 'Linux'
@@ -608,7 +608,7 @@ jobs:
           xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c
           'fluxbox >/tmp/shift-fluxbox.log 2>&1 & sleep 1;
           exec pnpm --dir apps/desktop exec playwright test
-          --project=${{ matrix.project }} --fully-parallel --shard=${{ matrix.shard }}'
+          --project=${{ matrix.project }} --fully-parallel --shard=${{ matrix.shard }}/${{ matrix.shard-total }}'
 
       - name: Upload platform evidence
         if: always() && matrix.project == 'platform'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -982,7 +982,7 @@ The authoritative milestone plan is the release roadmap at the top of this file.
 - [ ] Increase Rust unit test coverage
 - [ ] Integration tests for native bindings
 - [ ] Frontend component tests
-- [ ] E2E tests (Playwright)
+- [x] E2E tests (Playwright)
 - [ ] Visual regression tests
 
 **Performance**

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -12,6 +12,7 @@ Run commands from the repository root:
 | `pnpm test:e2e:visual`        | Run deterministic visual and interaction tests |
 | `pnpm test:e2e:visual:update` | Regenerate visual snapshots                    |
 | `pnpm test:e2e:gpu`           | Run hardware-GPU correctness tests             |
+| `pnpm test:e2e:platform`      | Run cross-platform desktop integration tests   |
 | `pnpm test:e2e:perf`          | Run Playwright performance measurements        |
 
 Append Playwright file and title filters to run the smallest relevant check:
@@ -45,11 +46,19 @@ Do not update snapshots merely to make a failure pass. Inspect the diff and conf
 
 ## Projects and fixtures
 
-| Project  | Fixture                   | Rendering                                         | CI policy                                 |
-| -------- | ------------------------- | ------------------------------------------------- | ----------------------------------------- |
-| `visual` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required in the merge queue and on `main` |
-| `gpu`    | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required in the merge queue and on `main` |
-| `perf`   | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only                   |
+| Project    | Fixture                   | Rendering                                         | CI policy                                       |
+| ---------- | ------------------------- | ------------------------------------------------- | ----------------------------------------------- |
+| `visual`   | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on macOS in merge queue and `main`     |
+| `platform` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on Windows/Linux in merge queue/`main` |
+| `gpu`      | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required on macOS in merge queue and `main`     |
+| `perf`     | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only                         |
+
+The `platform` project concentrates on native desktop boundaries: document lifecycle, Save and Save As, recovery after forced termination, application quit, native menus, Unicode filesystem paths, and import/export persistence. Headless Linux runs under Xvfb with Fluxbox so native maximize, focus, and window-placement behavior has a window manager; both are available in the Nix dev shell. GPU and performance behavior remain separate from this software-rendered suite.
+
+```sh
+xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c \
+  'fluxbox >/tmp/shift-fluxbox.log 2>&1 & sleep 1; exec pnpm test:e2e:platform'
+```
 
 Visual tests default to MutatorSans. Authored GPU and performance tests default to the MutatorSans designspace and accept another editable source through `SHIFT_E2E_FONT_PATH`. Preview residency tests default to MutatorSans TTF through `SHIFT_E2E_PREVIEW_FONT_PATH`; variable preview scrubbing defaults to Host Grotesk through `SHIFT_E2E_VARIABLE_PREVIEW_FONT_PATH`:
 
@@ -90,7 +99,7 @@ A snapshot match alone does not prove GPU content exists. Rendering tests that c
 
 ## Failures and artifacts
 
-Local failures are written to `apps/desktop/e2e/test-results/`. CI uploads the same directory as a Playwright artifact, including screenshots, diffs, traces, error context, and `electron-diagnostics` with window, renderer error/crash, main-process output, and process-exit evidence. Open a trace with:
+Local failures are written to `apps/desktop/e2e/test-results/`. CI uploads the same directory as a Playwright artifact, including screenshots, diffs, traces, error context, and `electron-diagnostics` with window, renderer error/crash, main-process output, and process-exit evidence. Windows/Linux platform jobs also retain successful evidence for 14 days: launcher, catalog, editor, and reopened-editor screenshots; the generated `.shift` document; the exported TTF; and a runtime/file-hash manifest. These screenshots are inspection artifacts rather than golden visual assertions. Open a trace with:
 
 ```sh
 pnpm --filter @shift/desktop exec playwright show-trace apps/desktop/e2e/test-results/<test>/trace.zip

--- a/apps/desktop/e2e/application-quit.spec.ts
+++ b/apps/desktop/e2e/application-quit.spec.ts
@@ -2,7 +2,7 @@ import { expect, type ElectronApplication, type Page } from "@playwright/test";
 import fs from "node:fs";
 import path from "node:path";
 import { documentTest as test, waitForWorkspaceReady } from "./fixtures/electronApp";
-import { openCatalogGlyph } from "./fixtures/appLocators";
+import { openGlyphRoute } from "./fixtures/appLocators";
 import {
   addSquare,
   hoverVisibleUnselectedPoint,
@@ -132,12 +132,16 @@ test("keeps authored document state isolated between windows", async ({ electron
   const secondPage = await createAnotherDirtyFont(firstPage, electronApp);
   const firstGlyphId = await glyphIdForName(firstPage, "newGlyph");
   const secondGlyphId = await glyphIdForName(secondPage, "newGlyph");
+  await Promise.all([
+    firstPage.waitForFunction(() => window.shift?.applyStatusCell.peek() === "idle"),
+    secondPage.waitForFunction(() => window.shift?.applyStatusCell.peek() === "idle"),
+  ]);
 
-  await openCatalogGlyph(firstPage, "newGlyph", firstGlyphId);
+  await openGlyphRoute(firstPage, firstGlyphId);
   await addSquare(firstPage);
   await selectVisiblePoint(firstPage);
   await hoverVisibleUnselectedPoint(firstPage);
-  await openCatalogGlyph(secondPage, "newGlyph", secondGlyphId);
+  await openGlyphRoute(secondPage, secondGlyphId);
 
   expect(await secondPage.evaluate(() => window.shift?.editor.selection.ids)).toEqual([]);
   expect(await secondPage.evaluate(() => window.shift?.editor.hover.id)).toBeNull();

--- a/apps/desktop/e2e/document-lifecycle.spec.ts
+++ b/apps/desktop/e2e/document-lifecycle.spec.ts
@@ -195,6 +195,7 @@ async function launchSecondInstance(
 ): Promise<void> {
   const executablePath = await electronApp.evaluate(() => process.execPath);
   await execFileAsync(executablePath, [
+    ...(process.platform === "linux" ? ["--no-sandbox"] : []),
     MAIN_JS,
     `--user-data-dir=${path.join(testRoot, "user-data")}`,
     documentPath,

--- a/apps/desktop/e2e/fixtures/appLocators.ts
+++ b/apps/desktop/e2e/fixtures/appLocators.ts
@@ -73,13 +73,18 @@ export async function waitForEditorReady(page: Page, glyphId: string): Promise<v
 }
 
 /**
- * Navigates directly to a glyph route and waits for its scene publication.
+ * Acquires a glyph, navigates to its editor route, and waits for scene publication.
  *
- * @param page - workspace window navigating to the editor.
- * @param glyphId - glyph identity that must own the published scene node.
+ * @param page - authored or preview workspace window navigating to the editor.
+ * @param glyphId - catalog identity to acquire before publishing the route.
+ * @throws {Error} when the workspace is unavailable or glyph acquisition fails.
  */
 export async function openGlyphRoute(page: Page, glyphId: string): Promise<void> {
-  await page.evaluate((id) => {
+  await page.evaluate(async (id) => {
+    const font = window.shift?.font;
+    if (!font) throw new Error("Expected font workspace");
+
+    await font.loadGlyph(id);
     window.location.hash = `#/editor/${encodeURIComponent(id)}`;
   }, glyphId);
   await waitForEditorReady(page, glyphId);

--- a/apps/desktop/e2e/fixtures/documentLifecycle.ts
+++ b/apps/desktop/e2e/fixtures/documentLifecycle.ts
@@ -9,6 +9,8 @@ import { once } from "node:events";
 import path from "node:path";
 import { MAIN_JS, waitForWorkspaceReady } from "./electronApp";
 
+export { killApp } from "./electronApp";
+
 export async function createNewFont(page: Page, electronApp: ElectronApplication): Promise<Page> {
   const workspaceWindow = electronApp.waitForEvent("window");
   await page.getByRole("button", { name: "New font", exact: true }).click();
@@ -139,13 +141,4 @@ export async function relaunchApp(
       SHIFT_E2E_SAVE_SHIFT_PATH: saveShiftPath,
     },
   });
-}
-
-export async function killApp(electronApp: ElectronApplication): Promise<void> {
-  const childProcess = electronApp.process();
-  if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
-
-  const exited = once(childProcess, "exit");
-  childProcess.kill("SIGKILL");
-  await exited;
 }

--- a/apps/desktop/e2e/fixtures/documentLifecycle.ts
+++ b/apps/desktop/e2e/fixtures/documentLifecycle.ts
@@ -101,9 +101,22 @@ export async function requestAppQuit(electronApp: ElectronApplication): Promise<
   });
 }
 
+/**
+ * Ensures the Electron process exits after a quit request or last-window shutdown.
+ *
+ * @param electronApp - application that may already be exiting on non-macOS platforms.
+ */
 export async function quitApp(electronApp: ElectronApplication): Promise<void> {
-  const exited = once(electronApp.process(), "exit");
-  await requestAppQuit(electronApp);
+  const childProcess = electronApp.process();
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
+
+  const exited = once(childProcess, "exit");
+  try {
+    await requestAppQuit(electronApp);
+  } catch {
+    if (childProcess.exitCode === null && childProcess.signalCode === null) await exited;
+    return;
+  }
   await exited;
 }
 

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -101,7 +101,12 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
     try {
       await use(testRoot);
     } finally {
-      fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      await fs.promises.rm(testRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      });
     }
   },
 
@@ -311,7 +316,12 @@ export const recoveryTest = base.extend<{ recoveryApp: RecoveryApp }>({
       });
     } finally {
       if (app) await killApp(app);
-      fs.rmSync(testRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      await fs.promises.rm(testRoot, {
+        recursive: true,
+        force: true,
+        maxRetries: 10,
+        retryDelay: 100,
+      });
     }
   },
 });

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -6,12 +6,14 @@ import {
   type ElectronApplication,
 } from "@playwright/test";
 import { createBridge } from "@shift/bridge";
+import { execFile } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import * as path from "path";
 import { once } from "events";
+import { promisify } from "node:util";
 import type { Axis, NamedInstance, Source, Unicode } from "@shift/types";
 import type { DirtyDocumentChoice } from "../../src/main/document/types";
 import { createAuthoredDocument } from "./fontSource";
@@ -43,6 +45,7 @@ export const GLYPHSPACKAGE_FONT_PATH = path.resolve(
 /** Fixed window size for deterministic snapshots. */
 const WINDOW_WIDTH = 1200;
 const WINDOW_HEIGHT = 600;
+const execFileAsync = promisify(execFile);
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -260,11 +263,7 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
         });
       }
 
-      if (childProcess && childProcess.exitCode === null && childProcess.signalCode === null) {
-        const exited = once(childProcess, "exit");
-        childProcess.kill("SIGKILL");
-        await exited;
-      }
+      if (childProcess) await terminateProcessTree(childProcess);
     }
   },
 
@@ -402,12 +401,34 @@ async function readyWorkspacePage(app: ElectronApplication): Promise<Page> {
   return page;
 }
 
-async function killApp(app: ElectronApplication): Promise<void> {
-  const childProcess = app.process();
+/**
+ * Force-terminates the application and all descendant processes.
+ *
+ * @param app - application whose process tree must release test resources.
+ * @throws {Error} when the platform termination command cannot stop a running application.
+ */
+export async function killApp(app: ElectronApplication): Promise<void> {
+  await terminateProcessTree(app.process());
+}
+
+/** Terminates an Electron process tree through a handle that survives Playwright disconnection. */
+async function terminateProcessTree(childProcess: ChildProcess): Promise<void> {
   if (childProcess.exitCode !== null || childProcess.signalCode !== null) return;
 
   const exited = once(childProcess, "exit");
-  childProcess.kill("SIGKILL");
+  if (process.platform === "win32") {
+    const pid = childProcess.pid;
+    if (pid === undefined) throw new Error("Electron process has no PID");
+
+    try {
+      await execFileAsync("taskkill", ["/F", "/PID", String(pid), "/T"]);
+    } catch (error) {
+      if (childProcess.exitCode === null && childProcess.signalCode === null) throw error;
+    }
+  } else {
+    childProcess.kill("SIGKILL");
+  }
+
   await exited;
 }
 

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -225,10 +225,11 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
           .toBe(true);
       }
 
+      await browserWindow.evaluate((window) => window.unmaximize());
+      await expect.poll(() => browserWindow.evaluate((window) => window.isMaximized())).toBe(false);
       await browserWindow.evaluate(
         (win, { w, h }) => {
-          win.unmaximize();
-          win.setSize(w, h);
+          win.setContentSize(w, h);
           win.center();
         },
         { w: WINDOW_WIDTH, h: WINDOW_HEIGHT },
@@ -373,10 +374,11 @@ async function launchShiftApp(
     }
 
     const browserWindow = await app.browserWindow(page);
+    await browserWindow.evaluate((window) => window.unmaximize());
+    await expect.poll(() => browserWindow.evaluate((window) => window.isMaximized())).toBe(false);
     await browserWindow.evaluate(
       (win, { w, h }) => {
-        win.unmaximize();
-        win.setSize(w, h);
+        win.setContentSize(w, h);
         win.center();
       },
       { w: WINDOW_WIDTH, h: WINDOW_HEIGHT },

--- a/apps/desktop/e2e/platform-integration.spec.ts
+++ b/apps/desktop/e2e/platform-integration.spec.ts
@@ -1,0 +1,164 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import type { ElectronApplication, Page, TestInfo } from "@playwright/test";
+import { documentTest as test, expect, waitForWorkspaceReady } from "./fixtures/electronApp";
+import { openGlyphRoute } from "./fixtures/appLocators";
+import {
+  createNewFont,
+  killApp,
+  quitApp,
+  relaunchApp,
+  runCommand,
+} from "./fixtures/documentLifecycle";
+import { addSquare } from "./fixtures/editorInteractions";
+
+const platformTest = test.extend({
+  saveShiftPath: async ({ testRoot }, use) => {
+    const directory = path.join(testRoot, "Saved fonts – ünicode");
+    fs.mkdirSync(directory, { recursive: true });
+    await use(path.join(directory, "試験 font.shift"));
+  },
+  exportTtfPath: async ({ testRoot }, use) => {
+    const directory = path.join(testRoot, "Exported fonts – ünicode");
+    fs.mkdirSync(directory, { recursive: true });
+    await use(path.join(directory, "書体 evidence.ttf"));
+  },
+});
+
+platformTest(
+  "saves, exports, and reopens through Unicode paths with inspectable evidence",
+  async ({ electronApp, page, saveShiftPath, exportTtfPath, testRoot }, testInfo) => {
+    await attachScreenshot(testInfo, "launcher", page);
+    const { workspacePage, glyphId } = await createEvidenceDocument(electronApp, page, testInfo);
+    await persistEvidence(electronApp, workspacePage, saveShiftPath, exportTtfPath, testInfo);
+    await reopenAndVerify(electronApp, testRoot, saveShiftPath, glyphId, testInfo);
+  },
+);
+
+async function createEvidenceDocument(
+  electronApp: ElectronApplication,
+  page: Page,
+  testInfo: TestInfo,
+): Promise<{ workspacePage: Page; glyphId: string }> {
+  const workspacePage = await createNewFont(page, electronApp);
+  await attachScreenshot(testInfo, "glyph-catalog", workspacePage);
+  await workspacePage.getByRole("button", { name: "Create glyph", exact: true }).click();
+  const glyphId = await glyphIdForName(workspacePage, "newGlyph");
+  await workspacePage.waitForFunction(() => window.shift?.applyStatusCell.peek() === "idle");
+  await openGlyphRoute(workspacePage, glyphId);
+  expect(await activeGlyphPointCount(workspacePage)).toBe(0);
+  expect(await addSquare(workspacePage)).toBe(4);
+  await attachScreenshot(testInfo, "editor", workspacePage);
+  return { workspacePage, glyphId };
+}
+
+async function persistEvidence(
+  electronApp: ElectronApplication,
+  page: Page,
+  saveShiftPath: string,
+  exportTtfPath: string,
+  testInfo: TestInfo,
+): Promise<void> {
+  await runCommand(page, electronApp, "file.save");
+  await expect.poll(() => fs.existsSync(saveShiftPath)).toBe(true);
+  await runCommand(page, electronApp, "file.exportTtf");
+  await expect.poll(() => fs.existsSync(exportTtfPath)).toBe(true);
+
+  await testInfo.attach("saved-document", {
+    path: saveShiftPath,
+    contentType: "application/x-shift-document",
+  });
+  await testInfo.attach("exported-font", {
+    path: exportTtfPath,
+    contentType: "font/ttf",
+  });
+  await attachManifest(testInfo, electronApp, saveShiftPath, exportTtfPath);
+}
+
+async function reopenAndVerify(
+  electronApp: ElectronApplication,
+  testRoot: string,
+  saveShiftPath: string,
+  glyphId: string,
+  testInfo: TestInfo,
+): Promise<void> {
+  await quitApp(electronApp);
+  const relaunchedApp = await relaunchApp(testRoot, saveShiftPath);
+
+  try {
+    const launcherPage = await relaunchedApp.firstWindow();
+    await launcherPage.waitForURL(/#\/launcher$/);
+    const workspaceWindow = relaunchedApp.waitForEvent("window");
+    await launcherPage.getByRole("button", { name: /Load font/ }).click();
+    const workspacePage = await workspaceWindow;
+    await waitForWorkspaceReady(workspacePage);
+    await openGlyphRoute(workspacePage, glyphId);
+    expect(await activeGlyphPointCount(workspacePage)).toBe(4);
+    await attachScreenshot(testInfo, "reopened-editor", workspacePage);
+  } finally {
+    await killApp(relaunchedApp);
+  }
+}
+
+async function glyphIdForName(page: Page, glyphName: string): Promise<string> {
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (name) => window.shift?.font.glyphRecords().find((glyph) => glyph.name === name)?.id,
+        glyphName,
+      ),
+    )
+    .not.toBeUndefined();
+  const glyphId = await page.evaluate(
+    (name) => window.shift?.font.glyphRecords().find((glyph) => glyph.name === name)?.id,
+    glyphName,
+  );
+  if (!glyphId) throw new Error(`Expected ${glyphName} glyph`);
+  return glyphId;
+}
+
+async function activeGlyphPointCount(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const editor = window.shift?.editor;
+    const node = editor?.scene.nodesOfKind("glyph")[0];
+    const glyph = node ? editor?.glyphForId(node.glyphId) : null;
+    if (!node || !glyph) throw new Error("Expected active glyph editor");
+    return glyph.layerForSource(node.sourceId)?.pointCount ?? 0;
+  });
+}
+
+async function attachScreenshot(testInfo: TestInfo, name: string, page: Page): Promise<void> {
+  const screenshotPath = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: screenshotPath });
+  await testInfo.attach(name, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+}
+
+async function attachManifest(
+  testInfo: TestInfo,
+  electronApp: ElectronApplication,
+  saveShiftPath: string,
+  exportTtfPath: string,
+): Promise<void> {
+  const runtime = await electronApp.evaluate(({ app }) => ({
+    platform: process.platform,
+    architecture: process.arch,
+    electronVersion: process.versions.electron,
+    appVersion: app.getVersion(),
+  }));
+  const files = [saveShiftPath, exportTtfPath].map((filePath) => ({
+    name: path.basename(filePath),
+    bytes: fs.statSync(filePath).size,
+    sha256: crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex"),
+  }));
+
+  const manifestPath = testInfo.outputPath("platform-manifest.json");
+  fs.writeFileSync(manifestPath, JSON.stringify({ ...runtime, files }, null, 2));
+  await testInfo.attach("platform-manifest", {
+    path: manifestPath,
+    contentType: "application/json",
+  });
+}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,6 +20,7 @@
     "test:e2e:visual": "playwright test --project=visual",
     "test:e2e:visual:update": "playwright test --project=visual --update-snapshots",
     "test:e2e:gpu": "playwright test --project=gpu",
+    "test:e2e:platform": "playwright test --project=platform",
     "test:e2e:perf": "playwright test --project=perf",
     "test:perf": "vitest bench --run"
   },

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -33,6 +33,11 @@ export default defineConfig({
       testIgnore: /(?:font-preview|glyph-grid|gpu|perf)\.spec/,
     },
     {
+      name: "platform",
+      testMatch:
+        /(?:application-menu|application-quit|document-lifecycle|document-recovery|platform-integration)\.spec/,
+    },
+    {
       name: "gpu",
       testMatch: /(?:font-preview|glyph-grid)\.spec/,
     },

--- a/flake.nix
+++ b/flake.nix
@@ -49,8 +49,10 @@
             at-spi2-atk
             cups
             dbus
+            fluxbox
             gtk3
             nss
+            xvfb-run
             libx11
             libxscrnsaver
             libxtst

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:e2e:visual": "turbo run build:e2e --filter=@shift/desktop && pnpm --dir apps/desktop exec playwright test --project=visual",
     "test:e2e:visual:update": "turbo run build:e2e --filter=@shift/desktop && pnpm --dir apps/desktop exec playwright test --project=visual --update-snapshots",
     "test:e2e:gpu": "turbo run build:e2e --filter=@shift/desktop && pnpm --dir apps/desktop exec playwright test --project=gpu",
+    "test:e2e:platform": "turbo run build:e2e --filter=@shift/desktop && pnpm --dir apps/desktop exec playwright test --project=platform",
     "test:e2e:perf": "turbo run build:e2e --filter=@shift/desktop && pnpm --dir apps/desktop exec playwright test --project=perf",
     "test:playwright": "pnpm test:e2e",
     "test:watch": "turbo run test:watch",

--- a/turbo.json
+++ b/turbo.json
@@ -142,6 +142,12 @@
       "outputs": [],
       "inputs": ["e2e/**", "playwright.config.ts", "src/**", "*.config.ts", "package.json"]
     },
+    "@shift/desktop#test:e2e:platform": {
+      "dependsOn": ["build:e2e"],
+      "cache": false,
+      "outputs": [],
+      "inputs": ["e2e/**", "playwright.config.ts", "src/**", "*.config.ts", "package.json"]
+    },
     "@shift/desktop#test:e2e:perf": {
       "dependsOn": ["build:e2e"],
       "cache": false,


### PR DESCRIPTION
## Summary

- build the Electron E2E app once per operating system and shard focused integration coverage across Windows and Linux
- verify Unicode save, export, quit, reopen, recovery, and empty-glyph editing workflows
- retain successful platform screenshots, documents, exported fonts, and runtime/file-hash manifests for inspection
- keep macOS visual and GPU coverage while deriving repeated shard jobs from compact matrix axes

## Issue

Closes #311

## Testing

- `xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c 'fluxbox >/tmp/shift-fluxbox.log 2>&1 & sleep 1; exec pnpm test:e2e:platform'` — 42 passed, 1 macOS-only test skipped
- `nix shell nixpkgs#actionlint -c actionlint .github/workflows/ci.yml`
- `cd apps/desktop && for project in visual platform; do for shard in 1/3 2/3 3/3; do ../../node_modules/.bin/playwright test --project="$project" --fully-parallel --shard="$shard" --list; done; done`
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `nix flake check --no-build`
- [Hosted CI run 33326380985](https://github.com/shift-editor/shift/actions/runs/33326380985) — OS builds, visual shards, GPU, and Linux platform shards 1/3 and 3/3 passed; Windows fixture teardown left Electron child processes holding temporary directories, and Linux shard 2/3 exposed an unconfigured sandbox for a directly launched second instance
- [Hosted CI run 33327665404](https://github.com/shift-editor/shift/actions/runs/33327665404) — all Linux platform, macOS visual, and GPU shards passed; Windows behavior completed but all three shards failed while deleting isolated temporary roots with `EPERM`, despite no Electron processes remaining for runner cleanup
- [Hosted CI run 33328494112](https://github.com/shift-editor/shift/actions/runs/33328494112) — all jobs passed, including every Windows and Linux platform shard, all macOS visual shards, and GPU coverage
- Windows execution not run locally; the new Windows CI jobs provide hosted validation
