### PR TITLE
ci: reduce cross-platform E2E runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,7 +455,7 @@ jobs:
       (github.event_name == 'merge_group' &&
         (needs.detect-changes.outputs.typescript == 'true' ||
           needs.detect-changes.outputs.rust == 'true')) ||
-      github.event_name == 'push' ||
+      (github.event_name == 'push' && needs.detect-changes.outputs.rust == 'true') ||
       github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
@@ -502,7 +502,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: crates/shift-bridge/*.node
-          key: native-module-${{ runner.os }}-${{ hashFiles('crates/**', 'Cargo.lock') }}
+          key: native-module-e2e-v1-${{ runner.os }}-${{ hashFiles('Cargo.toml', 'crates/**', 'Cargo.lock', 'rust-toolchain.toml') }}
 
       - uses: Swatinem/rust-cache@v2
         if: steps.native-cache.outputs.cache-hit != 'true'
@@ -511,15 +511,18 @@ jobs:
 
       - name: Build native module
         if: steps.native-cache.outputs.cache-hit != 'true'
-        run: pnpm build:native
+        run: pnpm build:native:e2e
 
       - name: Generate glyph info
+        if: github.event_name != 'push'
         run: pnpm generate:glyph-info
 
       - name: Build E2E app
+        if: github.event_name != 'push'
         run: pnpm --filter @shift/desktop build:e2e
 
       - name: Upload E2E app
+        if: github.event_name != 'push'
         uses: actions/upload-artifact@v7
         with:
           name: e2e-app-${{ github.run_id }}-${{ runner.os }}
@@ -532,6 +535,7 @@ jobs:
   e2e:
     name: E2E ${{ matrix.name }} ${{ matrix.shard }}/${{ matrix.shard-total }}
     needs: e2e-build
+    if: github.event_name != 'push'
     strategy:
       fail-fast: false
       matrix:
@@ -564,7 +568,6 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
-          submodules: true
 
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ shift-font = { path = "crates/shift-font" }
 shift-slug = { path = "crates/shift-slug" }
 shift-store = { path = "crates/shift-store" }
 shift-workspace = { path = "crates/shift-workspace" }
+
+[profile.e2e]
+inherits = "release"
+opt-level = 1
+codegen-units = 256

--- a/apps/desktop/e2e/README.md
+++ b/apps/desktop/e2e/README.md
@@ -46,12 +46,14 @@ Do not update snapshots merely to make a failure pass. Inspect the diff and conf
 
 ## Projects and fixtures
 
-| Project    | Fixture                   | Rendering                                         | CI policy                                       |
-| ---------- | ------------------------- | ------------------------------------------------- | ----------------------------------------------- |
-| `visual`   | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on macOS in merge queue and `main`     |
-| `platform` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on Windows/Linux in merge queue/`main` |
-| `gpu`      | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required on macOS in merge queue and `main`     |
-| `perf`     | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only                         |
+| Project    | Fixture                   | Rendering                                         | CI policy                                    |
+| ---------- | ------------------------- | ------------------------------------------------- | -------------------------------------------- |
+| `visual`   | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on macOS in the merge queue         |
+| `platform` | `fixtures/electronApp.ts` | Software rendering, DPR 1, `1200×600` page window | Required on Windows/Linux in the merge queue |
+| `gpu`      | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Required on macOS in the merge queue         |
+| `perf`     | `fixtures/perfApp.ts`     | Hardware GPU, host scale, stable content size     | Nightly and manual only                      |
+
+Post-merge `main` workflows do not repeat the E2E suites for the same commit. Rust-changing pushes still build each platform's native module to seed default-branch caches for later merge-queue runs.
 
 The `platform` project concentrates on native desktop boundaries: document lifecycle, Save and Save As, recovery after forced termination, application quit, native menus, Unicode filesystem paths, and import/export persistence. Headless Linux runs under Xvfb with Fluxbox so native maximize, focus, and window-placement behavior has a window manager; both are available in the Nix dev shell. GPU and performance behavior remain separate from this software-rendered suite.
 

--- a/apps/desktop/e2e/variable-font-recovery.spec.ts
+++ b/apps/desktop/e2e/variable-font-recovery.spec.ts
@@ -170,13 +170,17 @@ async function authorSourceTopology(page: Page): Promise<SourceFixture> {
 
     const medium = font.source(mediumSourceId);
     if (!medium) throw new Error("Expected Medium source");
+
+    const ascender = font.metricDefinitions.find(({ kind }) => kind === "ascender");
+    if (!ascender) throw new Error("Expected ascender metric");
+
     await font.updateSource({
       ...medium,
       name: "Medium Master",
       italicAngle: -2,
       lineGap: 37,
-      metricValues: medium.metricValues.map((value, index) =>
-        index === 0 ? { ...value, position: value.position + 17 } : value,
+      metricValues: medium.metricValues.map((value) =>
+        value.metricId === ascender.id ? { ...value, position: value.position + 17 } : value,
       ),
     });
 

--- a/crates/shift-bridge/package.json
+++ b/crates/shift-bridge/package.json
@@ -38,6 +38,7 @@
     "artifacts": "napi artifacts",
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
+    "build:e2e": "napi build --platform --profile e2e",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "vitest run",
     "universal": "napi universal",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dev:watch:release": "./scripts/watch.sh release",
     "build:native": "turbo run build --filter=shift-bridge",
     "build:native:debug": "turbo run build:debug --filter=shift-bridge",
+    "build:native:e2e": "turbo run build:e2e --filter=shift-bridge",
     "generate:bridge-types": "turbo run generate:bridge-types",
     "generate:types": "pnpm generate:bridge-types",
     "generate:glyph-info": "turbo run generate --filter=@shift/glyph-info",

--- a/packages/glyph-info/src/GlyphInfo.ts
+++ b/packages/glyph-info/src/GlyphInfo.ts
@@ -131,7 +131,8 @@ export class GlyphInfo {
   #decomposed: Map<number, number[]>;
   #usedBy: Map<number, number[]>;
   #charsets: CharsetDefinition[];
-  #searchIndex: MiniSearch;
+  #searchData: Record<string, unknown>[];
+  #searchIndex: MiniSearch | null = null;
 
   constructor(resources: GlyphInfoResources) {
     this.#glyphData = new Map(resources.glyphData.map((g) => [g.codepoint, g]));
@@ -158,14 +159,22 @@ export class GlyphInfo {
     );
 
     this.#charsets = resources.charsets;
+    this.#searchData = resources.searchData;
+  }
 
-    this.#searchIndex = new MiniSearch({
+  #getSearchIndex(): MiniSearch {
+    if (this.#searchIndex) return this.#searchIndex;
+
+    const searchIndex = new MiniSearch({
       fields: ["glyphName", "unicodeName", "altNames", "category", "subCategory"],
       storeFields: ["codepoint", "glyphName", "unicodeName", "category", "subCategory"],
       idField: "codepoint",
       searchOptions: { prefix: true, combineWith: "AND" },
     });
-    this.#searchIndex.addAll(resources.searchData);
+    searchIndex.addAll(this.#searchData);
+    this.#searchIndex = searchIndex;
+
+    return searchIndex;
   }
 
   // --- Glyph Data (Map lookups) ---
@@ -323,7 +332,7 @@ export class GlyphInfo {
     const sanitized = query.trim().replace(/['"()*:^{}]/g, " ");
     if (!sanitized.trim()) return [];
 
-    const results = this.#searchIndex.search(sanitized, {
+    const results = this.#getSearchIndex().search(sanitized, {
       prefix: true,
       combineWith: "AND",
     }) as unknown as GlyphSearchHit[];

--- a/turbo.json
+++ b/turbo.json
@@ -36,6 +36,21 @@
       ],
       "outputs": ["index.js", "index.d.ts", "*.node"]
     },
+    "shift-bridge#build:e2e": {
+      "inputs": [
+        "src/**",
+        "package.json",
+        "Cargo.toml",
+        "dts-header.d.ts",
+        "$TURBO_ROOT$/Cargo.toml",
+        "$TURBO_ROOT$/Cargo.lock",
+        "$TURBO_ROOT$/rust-toolchain.toml",
+        "$TURBO_ROOT$/crates/*/Cargo.toml",
+        "$TURBO_ROOT$/crates/*/build.rs",
+        "$TURBO_ROOT$/crates/*/src/**"
+      ],
+      "outputs": ["index.js", "index.d.ts", "*.node"]
+    },
     "generate:bridge-types": {
       "dependsOn": ["shift-bridge#build"],
       "inputs": [


### PR DESCRIPTION
## Summary

- avoid repeating full cross-platform E2E suites on `main` after the merge queue has tested the resulting commit, while preserving native cache seeding for Rust changes
- build the native bridge with a dedicated E2E profile and remove unnecessary shard setup
- defer glyph search indexing until first use and make the variable-font recovery fixture select the intended metric deterministically
- reduce a cold Windows native build from 8m03s to 6m45s and its E2E build job from 10m28s to 8m54s

## Issue

No issue — CI performance and maintenance only.

## Testing

- `pnpm --filter @shift/glyph-info test` — 83 tests passed
- `pnpm --filter @shift/glyph-info typecheck`
- `pnpm build:native:e2e`
- `pnpm --filter @shift/desktop build:e2e`
- `pnpm --dir apps/desktop exec playwright test --project=visual e2e/variable-font-recovery.spec.ts` — 2 tests passed
- `pnpm typecheck`
- [hosted CI workflow](https://github.com/shift-editor/shift/actions/runs/33333358189) — full macOS, Windows, and Linux E2E matrix passed
- YAML syntax validation and `git diff --check`

## Risks

The E2E bridge uses `opt-level = 1` instead of the release profile's full optimization. The complete hosted cross-platform suite passed with this profile. A separate local `opt-level = 0` experiment was not included; its long unsharded run encountered interactive macOS window-focus failures, so that more aggressive profile remains follow-up work.
