### PR TITLE
feat(document): discover and resume recoverable workspaces

### DIFF
--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -7,6 +7,7 @@ import type {
   ShellEventMap,
   WorkspaceDocumentIdentity,
   WorkspaceDocumentState,
+  WorkspaceRecovery,
 } from "../../shared/workspace/protocol";
 import { createShiftLogger, type ShiftLogger } from "../logging";
 
@@ -124,6 +125,16 @@ export class WorkspaceProcess {
    */
   openWorkspace(path: string): Promise<WorkspaceDocumentState> {
     return this.#requireChannel().call("workspace.open", { path });
+  }
+
+  /** Lists recoverable app-owned workspaces selected by the active distribution root. */
+  listRecoveries(): Promise<WorkspaceRecovery[]> {
+    return this.#requireChannel().call("workspace.listRecoveries", undefined);
+  }
+
+  /** Resumes one trusted app-owned working store selected by workspace id. */
+  resumeWorkspace(workspaceId: string): Promise<WorkspaceDocumentState> {
+    return this.#requireChannel().call("workspace.resume", { workspaceId });
   }
 
   /** Opens a retained read-only source without allocating a workspace document. */

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -70,6 +70,21 @@ export type WorkspaceSlugAtlasPageRequest = {
 
 export type WorkspaceDocumentSourceKind = "untitled" | "document" | "imported";
 
+/** Recoverable authored workspace discovered under the app-owned documents root. */
+export type WorkspaceRecovery =
+  | {
+      kind: "saved";
+      state: "recoverable";
+      workspaceId: string;
+      documentId: string;
+      canonicalPath: string;
+    }
+  | {
+      kind: "unsaved";
+      state: "recoverable";
+      workspaceId: string;
+    };
+
 /** Immutable product mode for one live font session. */
 export type FontSessionMode = "authored" | "preview";
 
@@ -170,6 +185,14 @@ export type ShellCallMap = {
   };
   "workspace.open": {
     request: { path: string };
+    response: WorkspaceDocumentState;
+  };
+  "workspace.listRecoveries": {
+    request: void;
+    response: WorkspaceRecovery[];
+  };
+  "workspace.resume": {
+    request: { workspaceId: string };
     response: WorkspaceDocumentState;
   };
   "workspace.close": { request: { discard: boolean }; response: null };

--- a/apps/desktop/src/utility/workspace/DocumentOpener.test.ts
+++ b/apps/desktop/src/utility/workspace/DocumentOpener.test.ts
@@ -118,6 +118,60 @@ describe("native document recovery allocations", () => {
     expect(canonicalGlyphNames(documentPath, root)).toEqual(["A"]);
   });
 
+  it("lists saved and unsaved recoverable workspaces", () => {
+    const saved = openDocument(documentPath, storage);
+    addGlyph(saved.bridge, "B", 66);
+    saved.bridge.closeWorkspace();
+
+    const unsaved = storage.createWorkspace();
+    const unsavedBridge = createBridge();
+    unsavedBridge.createUntitledWorkspace(unsaved.storePath);
+    unsavedBridge.setWorkspaceId(unsaved.workspaceId);
+    addGlyph(unsavedBridge, "C", 67);
+    unsavedBridge.closeWorkspace();
+
+    expect(storage.listRecoveries()).toEqual([
+      {
+        kind: "saved",
+        state: "recoverable",
+        workspaceId: saved.workspaceId,
+        documentId: createBridge().inspectDocument(documentPath).documentId,
+        canonicalPath: fs.realpathSync(documentPath),
+      },
+      { kind: "unsaved", state: "recoverable", workspaceId: unsaved.workspaceId },
+    ]);
+  });
+
+  it("rejects malformed recovery bindings during discovery", () => {
+    const opened = openDocument(documentPath, storage);
+    opened.bridge.closeWorkspace();
+    corruptRecoveryPath(root, documentPath);
+
+    expect(() => storage.listRecoveries()).toThrow("workspace path mismatch");
+    expect(fs.existsSync(opened.workspace.recoveryPath)).toBe(true);
+  });
+
+  it("resumes a complete unsaved working store without a source path", () => {
+    const unsaved = storage.createWorkspace();
+    const first = createBridge();
+    first.createUntitledWorkspace(unsaved.storePath);
+    first.setWorkspaceId(unsaved.workspaceId);
+    addGlyph(first, "A", 65);
+    first.closeWorkspace();
+
+    const resumed = createBridge();
+    resumed.resumeWorkspace(unsaved.storePath);
+    resumed.setWorkspaceId(unsaved.workspaceId);
+
+    expect(resumed.getGlyphs().map((glyph) => glyph.name)).toEqual(["A"]);
+    expect(resumed.documentState()).toMatchObject({
+      sourceKind: "untitled",
+      dirty: true,
+      needsSaveAs: true,
+    });
+    resumed.closeWorkspace();
+  });
+
   it("refuses a document replaced after identity inspection", () => {
     const bridge = createBridge();
     const identity = bridge.inspectDocument(documentPath);

--- a/apps/desktop/src/utility/workspace/DocumentStorage.ts
+++ b/apps/desktop/src/utility/workspace/DocumentStorage.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { z } from "zod";
+import type { WorkspaceRecovery } from "../../shared/workspace/protocol";
 import { DocumentAddress, type DocumentBinding, type WorkspaceAllocation } from "./types";
 
 const SQLITE_SIDECAR_SUFFIXES = ["", "-wal", "-shm", "-journal"] as const;
@@ -79,6 +80,45 @@ export class DocumentStorage {
     return binding;
   }
 
+  /** Lists every recoverable workspace allocation under this distribution root. */
+  listRecoveries(): WorkspaceRecovery[] {
+    const recoveries = new Map<string, WorkspaceRecovery>();
+    const savedWorkspaceIds = new Set<string>();
+
+    for (const binding of this.#listAllDocumentBindings()) {
+      savedWorkspaceIds.add(binding.workspaceId);
+      if (!fs.existsSync(binding.recoveryPath)) continue;
+
+      recoveries.set(`saved:${binding.workspaceId}`, {
+        kind: "saved",
+        state: "recoverable",
+        workspaceId: binding.workspaceId,
+        documentId: binding.documentId,
+        canonicalPath: binding.canonicalPath,
+      });
+    }
+
+    const workspacesPath = path.join(this.#rootPath, "workspaces");
+    if (!fs.existsSync(workspacesPath)) return sortRecoveries([...recoveries.values()]);
+
+    for (const entry of fs.readdirSync(workspacesPath, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      assertSafeSegment("workspace id", entry.name);
+      if (savedWorkspaceIds.has(entry.name)) continue;
+
+      const workspace = this.workspace(entry.name);
+      if (!fs.existsSync(workspace.storePath)) continue;
+
+      recoveries.set(`unsaved:${workspace.workspaceId}`, {
+        kind: "unsaved",
+        state: "recoverable",
+        workspaceId: workspace.workspaceId,
+      });
+    }
+
+    return sortRecoveries([...recoveries.values()]);
+  }
+
   /** Lists every path binding for one canonical document identity. */
   listDocumentBindings(documentId: string): DocumentBinding[] {
     assertSafeSegment("document id", documentId);
@@ -97,6 +137,34 @@ export class DocumentStorage {
     }
 
     return bindings.sort((left, right) => left.canonicalPath.localeCompare(right.canonicalPath));
+  }
+
+  #listAllDocumentBindings(): DocumentBinding[] {
+    const rootPath = path.join(this.#rootPath, "bindings");
+    if (!fs.existsSync(rootPath)) return [];
+
+    const bindings: DocumentBinding[] = [];
+    for (const documentEntry of fs.readdirSync(rootPath, { withFileTypes: true })) {
+      if (!documentEntry.isDirectory()) continue;
+      assertSafeSegment("document id", documentEntry.name);
+
+      const directoryPath = path.join(rootPath, documentEntry.name);
+      for (const entry of fs.readdirSync(directoryPath, { withFileTypes: true })) {
+        if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+
+        const bindingPath = path.join(directoryPath, entry.name);
+        const binding = readDocumentBinding(bindingPath);
+        const address = new DocumentAddress(documentEntry.name, binding.canonicalPath);
+        this.#validateBinding(address, binding, bindingPath);
+        bindings.push(binding);
+      }
+    }
+
+    return bindings.sort((left, right) =>
+      left.documentId === right.documentId
+        ? left.canonicalPath.localeCompare(right.canonicalPath)
+        : left.documentId.localeCompare(right.documentId),
+    );
   }
 
   /** Atomically binds one canonical document address to an app-local workspace. */
@@ -165,6 +233,15 @@ function readDocumentBinding(bindingPath: string): DocumentBinding {
     })
     .join("; ");
   throw new Error(`invalid document binding: ${bindingPath}: ${details}`);
+}
+
+function sortRecoveries(recoveries: WorkspaceRecovery[]): WorkspaceRecovery[] {
+  return recoveries.sort((left, right) => {
+    const kind = left.kind.localeCompare(right.kind);
+    if (kind !== 0) return kind;
+
+    return left.workspaceId.localeCompare(right.workspaceId);
+  });
 }
 
 function writeJsonAtomic(targetPath: string, value: unknown): void {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -714,6 +714,30 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     expect(canonicalGlyphNames(saved.path)).toEqual(["A", "B"]);
   });
 
+  it("lists recoveries and resumes an unsaved working database", async () => {
+    const sync = await connectSyncLane();
+    const created = await createWorkspace(sync);
+    await addGlyphB(sync);
+
+    const restarted = await startAdditionalHost();
+    await expect(restarted.shell.call("workspace.listRecoveries", undefined)).resolves.toEqual([
+      { kind: "unsaved", state: "recoverable", workspaceId: created.workspaceId },
+    ]);
+
+    const state = await restarted.shell.call("workspace.resume", {
+      workspaceId: created.workspaceId,
+    });
+    const snapshot = await restarted.sync.call("workspace.snapshot", undefined);
+
+    expect(state).toMatchObject({
+      workspaceId: created.workspaceId,
+      sourceKind: "untitled",
+      dirty: true,
+      needsSaveAs: true,
+    });
+    expect(snapshot?.glyphs.map((glyph) => glyph.name)).toEqual(["B"]);
+  });
+
   it("discard removes recovered edits without changing the canonical document", async () => {
     const source = await connectSyncLane();
     const saved = await saveDocumentWithGlyphA(source, "DiscardMe.shift");

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -108,6 +108,8 @@ export class WorkspaceHost {
         this.#serialize(() => this.#createFromSource(sourcePath, documentPath)),
       "workspace.inspectDocument": ({ path }) => this.#serialize(() => this.#inspectDocument(path)),
       "workspace.open": ({ path }) => this.#serialize(() => this.#open(path)),
+      "workspace.listRecoveries": () => this.#serialize(() => this.#documents.listRecoveries()),
+      "workspace.resume": ({ workspaceId }) => this.#serialize(() => this.#resume(workspaceId)),
       "workspace.close": ({ discard }) => this.#serialize(() => this.#close(discard)),
       "source.open": ({ path }) => this.#serialize(() => this.#openFontSource(path)),
       "source.close": () => this.#serialize(() => this.#closeFontSource()),
@@ -670,6 +672,24 @@ export class WorkspaceHost {
       binding: { kind: "bound", address: opened.address },
     };
     this.#atlasCacheRevision = null;
+    return this.#emitDocumentChanged();
+  }
+
+  #resume(workspaceId: string): WorkspaceDocumentState {
+    if (this.#state.kind !== "closed") {
+      throw new Error("a preview or document is already open");
+    }
+
+    const allocation = this.#documents.workspace(workspaceId);
+    this.#bridge.resumeWorkspace(allocation.storePath);
+    this.#bridge.setWorkspaceId(allocation.workspaceId);
+    this.#state = {
+      kind: "document",
+      allocation,
+      binding: { kind: "unbound" },
+    };
+    this.#atlasCacheRevision = null;
+
     return this.#emitDocumentChanged();
   }
 

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -24,6 +24,7 @@ export declare class Bridge {
   closeWorkspace(): void
   openDocument(path: string, recoveryPath: string): void
   openWorkspace(path: string, storePath: string): void
+  resumeWorkspace(storePath: string): void
   openFontSource(path: string): NapiFontSnapshot
   closeFontSource(): void
   setWorkspaceId(workspaceId: string): NapiDocumentState

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -1204,6 +1204,15 @@ impl Bridge {
   }
 
   #[napi]
+  pub fn resume_workspace(&mut self, store_path: String) -> errors::Result<()> {
+    self.workspace = Some(FontWorkspace::resume(store_path)?);
+    self.font_source = None;
+    self.source_identity = None;
+    self.reset_versions();
+    Ok(())
+  }
+
+  #[napi]
   pub fn open_font_source(&mut self, path: String) -> errors::Result<NapiFontSnapshot> {
     let source = FontLoader::new().open_source(Path::new(&path))?;
     let identity = SourceIdentity::new(source.directory())?;

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -39,6 +39,7 @@ export interface BridgeApi {
   closeWorkspace(): void
   openDocument(path: string, recoveryPath: string): void
   openWorkspace(path: string, storePath: string): void
+  resumeWorkspace(storePath: string): void
   openFontSource(path: string): FontSnapshot
   closeFontSource(): void
   setWorkspaceId(workspaceId: string): DocumentState


### PR DESCRIPTION
## Summary

- expose `resumeWorkspace` through the native bridge and shared shell lane
- add `WorkspaceRecovery` discovery for saved overlays and unsaved working stores under the active documents root
- keep malformed bindings/recovery data in place and verify resume with real SQLite stores

## Issue

Refs #91

## Testing

- `nix develop --command pnpm test:desktop src/utility/workspace/DocumentOpener.test.ts src/utility/workspace/WorkspaceHost.test.ts`
- `nix develop --command cargo test -p shift-workspace resume -- --nocapture`
- `nix develop --command pnpm lint:check`
- `nix develop --command pnpm typecheck`
- `nix develop --command pnpm format:check`
- `nix develop --command python3 scripts/context-drift-check.py` failed with existing stale-doc review warnings only
- E2E not run locally; Electron E2E is expected to run in CI for this stacked branch
