### PR TITLE
feat(desktop): reopen recoverable documents at startup

### DIFF
--- a/apps/desktop/e2e/document-crash.spec.ts
+++ b/apps/desktop/e2e/document-crash.spec.ts
@@ -1,0 +1,51 @@
+import type { ElectronApplication, Page } from "@playwright/test";
+import type { GlyphName } from "@shift/types";
+import { expect, workspaceTest as test, waitForWorkspaceReady } from "./fixtures/electronApp";
+
+test.setTimeout(90_000);
+test.use({ scriptedDialogs: true });
+
+test("reopens a crashed document renderer with completed edits", async ({ electronApp, page }) => {
+  const glyphName = "rendererCrashRecovery" as GlyphName;
+  await page.evaluate((name) => {
+    window.shift?.editor.createGlyph(name);
+  }, glyphName);
+  await waitForGlyph(page, glyphName);
+
+  const reopenedPage = await crashRendererAndWaitForWindow(electronApp, page);
+  await waitForWorkspaceReady(reopenedPage);
+  await waitForGlyph(reopenedPage, glyphName);
+
+  await expect.poll(() => electronApp.windows().length).toBe(1);
+});
+
+async function crashRendererAndWaitForWindow(
+  electronApp: ElectronApplication,
+  page: Page,
+): Promise<Page> {
+  const nextWindow = electronApp.waitForEvent("window");
+  const browserWindow = await electronApp.browserWindow(page);
+  await browserWindow.evaluate((window) => {
+    window.webContents.forcefullyCrashRenderer();
+  });
+  await browserWindow.dispose();
+
+  const reopenedPage = await nextWindow;
+  await reopenedPage.waitForLoadState("domcontentloaded");
+  return reopenedPage;
+}
+
+async function waitForGlyph(page: Page, glyphName: GlyphName): Promise<void> {
+  await page.waitForFunction(
+    (name) => {
+      const workspace = window.shift;
+      return (
+        workspace?.applyStatusCell.peek() === "idle" &&
+        workspace.documentStateCell.peek()?.dirty === true &&
+        workspace.font.recordForName(name as GlyphName) !== null
+      );
+    },
+    glyphName,
+    { timeout: 20_000 },
+  );
+}

--- a/apps/desktop/e2e/document-recovery.spec.ts
+++ b/apps/desktop/e2e/document-recovery.spec.ts
@@ -62,8 +62,14 @@ test("recovers batched glyph undo", async ({ recoveryApp }) => {
   await save(recovered);
   expect(recoveryApp.canonicalGlyphNames()).not.toEqual(expect.arrayContaining(glyphNames));
 
+  const followupGlyph = "recoveryAfterSave" as GlyphName;
+  await recovered.evaluate((name) => {
+    window.shift?.editor.createGlyph(name);
+  }, followupGlyph);
+  await waitForGlyphsAndState(recovered, [followupGlyph], true, true);
+
   const reopened = await recoveryApp.crashAndRestart();
-  await waitForGlyphsAndState(reopened, glyphNames, false, false);
+  await waitForGlyphsAndState(reopened, [followupGlyph], true, true);
 });
 
 async function save(page: Page): Promise<void> {

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -307,7 +307,7 @@ export const recoveryTest = base.extend<{ recoveryApp: RecoveryApp }>({
           if (!app) throw new Error("Electron application is not running");
 
           await killApp(app);
-          app = await launchShiftApp(userDataDir, documentPath);
+          app = await launchShiftApp(userDataDir);
           page = await readyWorkspacePage(app);
           return page;
         },
@@ -361,16 +361,18 @@ export async function waitForWorkspaceReady(page: Page): Promise<void> {
 
 async function launchShiftApp(
   userDataDir: string,
-  workspacePath: string,
+  workspacePath?: string,
 ): Promise<ElectronApplication> {
+  const environment = {
+    ...process.env,
+    NODE_ENV: "test",
+    LIBGL_ALWAYS_SOFTWARE: "1",
+  };
+  if (workspacePath) environment.SHIFT_E2E_FONT_PATH = workspacePath;
+
   const app = await electron.launch({
     args: [MAIN_JS, `--user-data-dir=${userDataDir}`, "--force-device-scale-factor=1"],
-    env: {
-      ...process.env,
-      NODE_ENV: "test",
-      LIBGL_ALWAYS_SOFTWARE: "1",
-      SHIFT_E2E_FONT_PATH: workspacePath,
-    },
+    env: environment,
   });
 
   try {

--- a/apps/desktop/e2e/fixtures/electronApp.ts
+++ b/apps/desktop/e2e/fixtures/electronApp.ts
@@ -69,6 +69,7 @@ type ShiftOptions = {
   dirtyDocumentChoice: DirtyDocumentChoice;
   dirtyDocumentChoices: readonly DirtyDocumentChoice[] | undefined;
   dirtyDocumentDelayMs: number;
+  documentCrashChoice: "reopen" | "close";
 };
 
 export interface CanonicalVariableFont {
@@ -94,6 +95,7 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
   dirtyDocumentChoice: ["cancel", { option: true }],
   dirtyDocumentChoices: [undefined, { option: true }],
   dirtyDocumentDelayMs: [0, { option: true }],
+  documentCrashChoice: ["reopen", { option: true }],
 
   testRoot: async ({}, use) => {
     const testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "shift-e2e-"));
@@ -135,6 +137,7 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
       dirtyDocumentChoice,
       dirtyDocumentChoices,
       dirtyDocumentDelayMs,
+      documentCrashChoice,
       testRoot,
       saveShiftPath,
       exportTtfPath,
@@ -179,6 +182,7 @@ export const test = base.extend<ShiftFixtures & ShiftOptions>({
         environment.SHIFT_E2E_DIRTY_DOCUMENT_DELAY_MS = String(dirtyDocumentDelayMs);
       }
       if (openFontPath) environment.SHIFT_E2E_OPEN_FONT_PATH = openFontPath;
+      environment.SHIFT_E2E_DOCUMENT_CRASH_CHOICE = documentCrashChoice;
     }
 
     try {

--- a/apps/desktop/playwright.config.ts
+++ b/apps/desktop/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     {
       name: "platform",
       testMatch:
-        /(?:application-menu|application-quit|document-lifecycle|document-recovery|platform-integration)\.spec/,
+        /(?:application-menu|application-quit|document-crash|document-lifecycle|document-recovery|platform-integration)\.spec/,
     },
     {
       name: "gpu",

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -53,6 +53,7 @@ export class App {
   #documentsRoot: string | null = null;
   #pendingOpenPaths: string[] = [];
   #previewConversions = new Map<string, Promise<void>>();
+  #documentCrashDecisions = new Map<string, Promise<void>>();
 
   #appIcon = new AppIcon();
   #applicationMenu = new ApplicationMenu(
@@ -103,6 +104,7 @@ export class App {
       documentsRoot: () => this.#requireDocumentsRoot(),
       applicationName: () => this.applicationName,
       nativeDialogs: this.#nativeDialogs,
+      onSessionCrashed: (session) => this.#handleDocumentCrash(session, null),
     });
     this.#lifecycle = new AppLifecycle({
       documentForWindow: (window) => {
@@ -240,6 +242,14 @@ export class App {
         : {}),
     });
     this.#windows.add(window);
+    window.window.webContents.on("render-process-gone", (_event, details) => {
+      if (details.reason === "clean-exit") return;
+
+      const session = this.#workspaces.getForBrowserWindow(window.window);
+      if (!session?.document) return;
+
+      this.#handleDocumentCrash(session, window);
+    });
 
     this.#lifecycle.registerWindow(window, {
       onClosed: () => {
@@ -265,6 +275,64 @@ export class App {
 
   #loadLauncher(window: Window): void {
     this.#loadRenderer(window, "/launcher");
+  }
+
+  #handleDocumentCrash(session: FontSessionHost, failedWindow: Window | null): void {
+    const existing = this.#documentCrashDecisions.get(session.workspaceId);
+    if (existing) return;
+
+    const handling = this.#documentCrashFlow(session.workspaceId, failedWindow);
+    this.#documentCrashDecisions.set(session.workspaceId, handling);
+    void handling
+      .catch((error) => {
+        this.#log.error("document crash flow failed", error);
+      })
+      .finally(() => {
+        if (this.#documentCrashDecisions.get(session.workspaceId) === handling) {
+          this.#documentCrashDecisions.delete(session.workspaceId);
+        }
+      });
+  }
+
+  async #documentCrashFlow(sessionId: string, failedWindow: Window | null): Promise<void> {
+    let failure: "crashed" | "restoreFailed" = "crashed";
+
+    while (true) {
+      const session = this.#workspaces.get(sessionId);
+      const owner = failedWindow ?? session?.activeWindow() ?? null;
+      const choice = await this.#nativeDialogs.confirmDocumentReopen(
+        owner,
+        this.applicationName,
+        failure,
+      );
+      if (choice === "close") {
+        for (const window of this.#crashedWindows(session, failedWindow)) {
+          if (!window.window.isDestroyed()) window.window.destroy();
+        }
+        return;
+      }
+
+      try {
+        const reopened = await this.#workspaces.reopenSession(sessionId);
+        const bounds = owner?.window.isDestroyed() ? undefined : owner?.window.getBounds();
+        const window = this.#createWindow(false, bounds);
+        this.#workspaces.attachWindow(reopened.workspaceId, window);
+        this.#loadWorkspace(window);
+
+        for (const crashedWindow of this.#crashedWindows(session, failedWindow)) {
+          if (!crashedWindow.window.isDestroyed()) crashedWindow.window.destroy();
+        }
+        return;
+      } catch (error) {
+        this.#log.error("failed to reopen crashed document", error);
+        failure = "restoreFailed";
+      }
+    }
+  }
+
+  #crashedWindows(session: FontSessionHost | null, failedWindow: Window | null): Window[] {
+    if (failedWindow) return [failedWindow];
+    return session?.allWindows() ?? [];
   }
 
   #loadWorkspace(window: Window): void {

--- a/apps/desktop/src/main/app/App.ts
+++ b/apps/desktop/src/main/app/App.ts
@@ -179,6 +179,13 @@ export class App {
 
       this.#documentsRoot = path.join(app.getPath("userData"), "working-documents");
 
+      const restoredSessions = await this.#workspaces.restoreRecoveries();
+      for (const session of restoredSessions) {
+        const window = this.#createWindow(false, undefined, true);
+        this.#workspaces.attachWindow(session.workspaceId, window);
+        this.#loadWorkspace(window);
+      }
+
       this.#appIcon.install();
       this.#applicationMenu.install();
       app.on("browser-window-focus", () => {

--- a/apps/desktop/src/main/dialogs/NativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/NativeDialogs.ts
@@ -1,5 +1,5 @@
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
-import type { CloseReason, DirtyDocumentChoice } from "../document/types";
+import type { CloseReason, DirtyDocumentChoice, DocumentCrashChoice } from "../document/types";
 import type { Window } from "../windows/Window";
 
 /** Owns native user choices at the outer Electron dialog boundary. */
@@ -63,6 +63,20 @@ export interface NativeDialogs {
     reason: CloseReason,
     applicationName: string,
   ): Promise<DirtyDocumentChoice>;
+
+  /**
+   * Confirms whether a crashed document should be reconstructed.
+   *
+   * @param window - native window that should own the confirmation.
+   * @param applicationName - product name shown by the native shell.
+   * @param failure - whether this is the first crash prompt or a failed reopen retry prompt.
+   * @returns the user's Reopen/Try Again or Close Window choice.
+   */
+  confirmDocumentReopen(
+    window: Window | null,
+    applicationName: string,
+    failure: "crashed" | "restoreFailed",
+  ): Promise<DocumentCrashChoice>;
 
   /**
    * Shows a blocking failure after a document save was refused or failed.

--- a/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/electronNativeDialogs.ts
@@ -130,6 +130,30 @@ export const electronNativeDialogs: NativeDialogs = {
     }
   },
 
+  async confirmDocumentReopen(window, applicationName, failure) {
+    const options: MessageBoxOptions = {
+      type: failure === "crashed" ? "warning" : "error",
+      buttons: failure === "crashed" ? ["Reopen", "Close Window"] : ["Try Again", "Close Window"],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      title: applicationName,
+      message:
+        failure === "crashed"
+          ? "The document window closed unexpectedly."
+          : "The document could not be reopened.",
+      detail:
+        failure === "crashed"
+          ? "Reopen the document to continue where you left off. Your unsaved changes have been preserved."
+          : "Your recovery data has been retained.",
+    };
+    const result = window
+      ? await dialog.showMessageBox(window.window, options)
+      : await dialog.showMessageBox(options);
+
+    return result.response === 0 ? "reopen" : "close";
+  },
+
   async showSaveFailure(window, applicationName, error) {
     await showFailure(window, applicationName, "The document could not be saved.", error);
   },

--- a/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
+++ b/apps/desktop/src/main/dialogs/scriptedNativeDialogs.ts
@@ -1,4 +1,4 @@
-import type { DirtyDocumentChoice } from "../document/types";
+import type { DirtyDocumentChoice, DocumentCrashChoice } from "../document/types";
 import type { NativeDialogs } from "./NativeDialogs";
 
 const dirtyDocumentChoices = parseDirtyDocumentChoices(
@@ -44,10 +44,23 @@ export const scriptedNativeDialogs: NativeDialogs = {
     return dirtyDocumentChoice(process.env.SHIFT_E2E_DIRTY_DOCUMENT_CHOICE);
   },
 
+  async confirmDocumentReopen() {
+    return documentCrashChoice(process.env.SHIFT_E2E_DOCUMENT_CRASH_CHOICE);
+  },
+
   async showSaveFailure() {},
 
   async showExportFailure() {},
 };
+
+function documentCrashChoice(value: string | undefined): DocumentCrashChoice {
+  switch (value) {
+    case "close":
+      return "close";
+    default:
+      return "reopen";
+  }
+}
 
 function dirtyDocumentChoice(value: string | undefined): DirtyDocumentChoice {
   switch (value) {

--- a/apps/desktop/src/main/document/types.ts
+++ b/apps/desktop/src/main/document/types.ts
@@ -1,3 +1,4 @@
 export type CloseReason = "window" | "quit" | "update";
 
 export type DirtyDocumentChoice = "save" | "discard" | "cancel";
+export type DocumentCrashChoice = "reopen" | "close";

--- a/apps/desktop/src/main/workspace/FontSessionHost.ts
+++ b/apps/desktop/src/main/workspace/FontSessionHost.ts
@@ -17,6 +17,7 @@ export type FontSessionHostOptions =
       readonly documentClient: DocumentClient;
       readonly applicationName: () => string;
       readonly nativeDialogs: NativeDialogs;
+      readonly onWorkspaceExit?: (session: FontSessionHost) => void;
     }
   | {
       readonly mode: "preview";
@@ -68,6 +69,7 @@ export class FontSessionHost {
         });
         this.#unlistenWorkspaceExit = this.workspaceProcess.onExit(() => {
           this.documentClient?.dispose();
+          if (options.onWorkspaceExit) options.onWorkspaceExit(this);
         });
         break;
       case "preview":

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -18,6 +18,7 @@ export interface WorkspaceManagerOptions {
   readonly documentsRoot: () => string;
   readonly applicationName: () => string;
   readonly nativeDialogs: NativeDialogs;
+  readonly onSessionCrashed?: (session: FontSessionHost) => void;
 }
 
 /**
@@ -33,6 +34,7 @@ export class WorkspaceManager {
   readonly #documentsRoot: () => string;
   readonly #applicationName: () => string;
   readonly #nativeDialogs: NativeDialogs;
+  readonly #onSessionCrashed: (session: FontSessionHost) => void;
   readonly #sessionsById = new Map<FontSessionId, FontSessionHost>();
   readonly #sessionIdByWindowId = new Map<number, FontSessionId>();
   readonly #documentSessions = new DocumentSessionIndex();
@@ -47,6 +49,7 @@ export class WorkspaceManager {
     this.#documentsRoot = options.documentsRoot;
     this.#applicationName = options.applicationName;
     this.#nativeDialogs = options.nativeDialogs;
+    this.#onSessionCrashed = options.onSessionCrashed ?? (() => {});
   }
 
   /**
@@ -300,6 +303,7 @@ export class WorkspaceManager {
       documentClient: new DocumentClient(),
       applicationName: this.#applicationName,
       nativeDialogs: this.#nativeDialogs,
+      onWorkspaceExit: (crashedSession) => this.#onSessionCrashed(crashedSession),
     });
 
     session.document?.acceptState(state);
@@ -325,6 +329,22 @@ export class WorkspaceManager {
       default:
         assertNever(recovery);
     }
+  }
+
+  async reopenSession(sessionId: FontSessionId): Promise<FontSessionHost> {
+    const session = this.#requireWorkspace(sessionId);
+    if (session.mode !== "authored") {
+      throw new Error(`Cannot reopen preview session: ${sessionId}`);
+    }
+    if (session.workspaceProcess.running) return session;
+
+    const windows = session.allWindows();
+    this.unregister(session.workspaceId);
+    const reopened = await this.#createSession((workspaceProcess) =>
+      workspaceProcess.resumeWorkspace(sessionId),
+    );
+    for (const window of windows) this.#sessionIdByWindowId.delete(window.window.id);
+    return reopened;
   }
 
   async #openDocument(

--- a/apps/desktop/src/main/workspace/WorkspaceManager.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceManager.ts
@@ -6,6 +6,7 @@ import type { Window } from "../windows/Window";
 import type {
   WorkspaceDocumentIdentity,
   WorkspaceDocumentState,
+  WorkspaceRecovery,
 } from "../../shared/workspace/protocol";
 import { WorkspaceProcess } from "./WorkspaceProcess";
 import { FontSessionHost, type FontSessionId } from "./FontSessionHost";
@@ -69,6 +70,44 @@ export class WorkspaceManager {
     return this.#createSession((workspaceProcess) =>
       workspaceProcess.createDocumentFromSource(sourcePath, documentPath),
     );
+  }
+
+  /** Restores every dirty recoverable workspace beneath the active documents root. */
+  async restoreRecoveries(): Promise<FontSessionHost[]> {
+    const discoveryProcess = new WorkspaceProcess();
+    discoveryProcess.start(this.#documentsRoot());
+
+    let recoveries: WorkspaceRecovery[];
+    try {
+      await discoveryProcess.whenReady();
+      recoveries = await discoveryProcess.listRecoveries();
+    } catch (error) {
+      console.warn("failed to discover workspace recoveries", error);
+      recoveries = [];
+    } finally {
+      discoveryProcess.stop();
+    }
+
+    const restored: FontSessionHost[] = [];
+    for (const recovery of recoveries) {
+      try {
+        const session = await this.#restoreRecovery(recovery);
+        if (restored.includes(session)) continue;
+
+        const state = await session.workspaceProcess.documentState();
+        if (state?.dirty) {
+          restored.push(session);
+          continue;
+        }
+
+        await session.workspaceProcess.closeWorkspace(false);
+        this.unregister(session.workspaceId);
+      } catch (error) {
+        console.warn("failed to restore workspace recovery", recovery, error);
+      }
+    }
+
+    return restored;
   }
 
   /**
@@ -275,6 +314,19 @@ export class WorkspaceManager {
     return session;
   }
 
+  async #restoreRecovery(recovery: WorkspaceRecovery): Promise<FontSessionHost> {
+    switch (recovery.kind) {
+      case "saved":
+        return this.openPath(recovery.canonicalPath);
+      case "unsaved":
+        return this.#createSession((workspaceProcess) =>
+          workspaceProcess.resumeWorkspace(recovery.workspaceId),
+        );
+      default:
+        assertNever(recovery);
+    }
+  }
+
   async #openDocument(
     sourcePath: string,
     workspaceProcess: WorkspaceProcess,
@@ -332,4 +384,8 @@ export class WorkspaceManager {
 
 function isShiftDocumentPath(sourcePath: string): boolean {
   return path.extname(sourcePath).toLowerCase() === ".shift";
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unknown workspace recovery: ${JSON.stringify(value)}`);
 }

--- a/apps/desktop/src/main/workspace/WorkspaceProcess.ts
+++ b/apps/desktop/src/main/workspace/WorkspaceProcess.ts
@@ -58,6 +58,11 @@ export class WorkspaceProcess {
     this.#wire(proc, channel);
   }
 
+  /** Whether the utility process is currently available for shell-lane calls. */
+  get running(): boolean {
+    return this.#process !== null && this.#channel !== null;
+  }
+
   /** Stops the utility process; in-flight shell-lane calls reject. */
   stop(): void {
     const proc = this.#process;


### PR DESCRIPTION
## Summary

- restore dirty saved and unsaved recoveries before launcher selection
- prune successfully inspected clean recovery allocations while retaining failed recoveries
- update the recovery E2E fixture so relaunch supplies only the user-data root

## Issue

Refs #91

## Testing

- `nix develop --command pnpm test:desktop src/utility/workspace/DocumentOpener.test.ts src/utility/workspace/WorkspaceHost.test.ts`
- `nix develop --command pnpm test:e2e:visual e2e/document-recovery.spec.ts`
- `nix develop --command pnpm test:e2e:platform e2e/document-recovery.spec.ts`
- `nix develop --command pnpm lint:check`
- `nix develop --command pnpm typecheck`
- `nix develop --command pnpm format:check`
- `nix develop --command python3 scripts/context-drift-check.py` failed locally with stale-doc review warnings only
