### PR TITLE
chore(skills): require visual review evidence

### DIFF
--- a/.agents/skills/issue/SKILL.md
+++ b/.agents/skills/issue/SKILL.md
@@ -52,6 +52,18 @@ Add reproduction steps, evidence, constraints, or out-of-scope notes only when t
 
 Acceptance criteria must describe behavior or durable repository outcomes. Do not use vague criteria such as “works correctly,” “tests pass,” or “code is clean.”
 
+### UI evidence
+
+For UI defects or visual-change requests whose appearance matters, attach screenshots or recordings when the affected state can be reproduced safely.
+
+- Show the actual affected UI and the state that demonstrates the problem or review need.
+- Prefer GitHub user attachments over committing issue-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- Label conceptual mockups as proposals; never present them as the current implementation.
+- If useful evidence cannot be captured safely or reliably, state why instead of fabricating it.
+
+Do not require visual evidence when the issue has no visible review surface.
+
 ## Pull request linkage
 
 Issue state has these meanings:

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -71,7 +71,19 @@ Testing entries must distinguish:
 - checks not run;
 - focused manual verification where an automated test would be low value.
 
-For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+
+### UI review evidence
+
+For materially visible UI changes, attach screenshots or recordings before marking the pull request ready for review.
+
+- Cover every distinct state needed to review the change, including native dialogs and fallback, error, empty, loading, or disabled states when affected.
+- Capture the actual implementation. Include before-and-after evidence when the change intentionally modifies existing appearance or interaction.
+- Prefer GitHub user attachments over committing review-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- If useful evidence cannot be captured safely or reliably, state why in the pull request rather than silently omitting it.
+
+Do not add ceremonial screenshots for changes with no visible review surface.
 
 ### Desktop E2E impact
 

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -52,6 +52,18 @@ Add reproduction steps, evidence, constraints, or out-of-scope notes only when t
 
 Acceptance criteria must describe behavior or durable repository outcomes. Do not use vague criteria such as “works correctly,” “tests pass,” or “code is clean.”
 
+### UI evidence
+
+For UI defects or visual-change requests whose appearance matters, attach screenshots or recordings when the affected state can be reproduced safely.
+
+- Show the actual affected UI and the state that demonstrates the problem or review need.
+- Prefer GitHub user attachments over committing issue-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- Label conceptual mockups as proposals; never present them as the current implementation.
+- If useful evidence cannot be captured safely or reliably, state why instead of fabricating it.
+
+Do not require visual evidence when the issue has no visible review surface.
+
 ## Pull request linkage
 
 Issue state has these meanings:

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -71,7 +71,19 @@ Testing entries must distinguish:
 - checks not run;
 - focused manual verification where an automated test would be low value.
 
-For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+
+### UI review evidence
+
+For materially visible UI changes, attach screenshots or recordings before marking the pull request ready for review.
+
+- Cover every distinct state needed to review the change, including native dialogs and fallback, error, empty, loading, or disabled states when affected.
+- Capture the actual implementation. Include before-and-after evidence when the change intentionally modifies existing appearance or interaction.
+- Prefer GitHub user attachments over committing review-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- If useful evidence cannot be captured safely or reliably, state why in the pull request rather than silently omitting it.
+
+Do not add ceremonial screenshots for changes with no visible review surface.
 
 ### Desktop E2E impact
 

--- a/.codex/skills/issue/SKILL.md
+++ b/.codex/skills/issue/SKILL.md
@@ -52,6 +52,18 @@ Add reproduction steps, evidence, constraints, or out-of-scope notes only when t
 
 Acceptance criteria must describe behavior or durable repository outcomes. Do not use vague criteria such as “works correctly,” “tests pass,” or “code is clean.”
 
+### UI evidence
+
+For UI defects or visual-change requests whose appearance matters, attach screenshots or recordings when the affected state can be reproduced safely.
+
+- Show the actual affected UI and the state that demonstrates the problem or review need.
+- Prefer GitHub user attachments over committing issue-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- Label conceptual mockups as proposals; never present them as the current implementation.
+- If useful evidence cannot be captured safely or reliably, state why instead of fabricating it.
+
+Do not require visual evidence when the issue has no visible review surface.
+
 ## Pull request linkage
 
 Issue state has these meanings:

--- a/.codex/skills/pr/SKILL.md
+++ b/.codex/skills/pr/SKILL.md
@@ -71,7 +71,19 @@ Testing entries must distinguish:
 - checks not run;
 - focused manual verification where an automated test would be low value.
 
-For UI changes, include screenshots or recordings when available and useful. For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+For release changes, state whether packaging was smoke-tested and which hosted platform/signing checks remain.
+
+### UI review evidence
+
+For materially visible UI changes, attach screenshots or recordings before marking the pull request ready for review.
+
+- Cover every distinct state needed to review the change, including native dialogs and fallback, error, empty, loading, or disabled states when affected.
+- Capture the actual implementation. Include before-and-after evidence when the change intentionally modifies existing appearance or interaction.
+- Prefer GitHub user attachments over committing review-only media to the repository.
+- Redact private user data, credentials, and sensitive documents before uploading.
+- If useful evidence cannot be captured safely or reliably, state why in the pull request rather than silently omitting it.
+
+Do not add ceremonial screenshots for changes with no visible review surface.
 
 ### Desktop E2E impact
 


### PR DESCRIPTION
## Summary

- require screenshots or recordings for materially visible pull request changes
- require safe visual evidence for reproducible UI issues and visual-change requests
- prefer GitHub attachments, protect sensitive data, and document capture limitations
- synchronize the canonical rules to Claude and Codex adapters

## Issue

No issue — small agent workflow policy update.

## Testing

- `nix develop --command pnpm agent-skills:check`
- `git diff --check`
