### PR TITLE
ci: wait for packaged renderer readiness

### DIFF
--- a/scripts/smoke-packaged.mjs
+++ b/scripts/smoke-packaged.mjs
@@ -150,6 +150,22 @@ async function waitForDebugEndpoint(url, child, output) {
   throw new Error(`Timed out waiting for the packaged app\n${output.join("")}`);
 }
 
+async function waitForRendererPage(browser, child, output) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const page = browser.contexts().flatMap((context) => context.pages())[0];
+    if (page) return page;
+
+    if (child.exitCode !== null) {
+      throw new Error(`Packaged app exited with code ${child.exitCode}\n${output.join("")}`);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(`Timed out waiting for the packaged renderer page\n${output.join("")}`);
+}
+
 const testRoot = await mkdtemp(path.join(os.tmpdir(), "shift-packaged-smoke-"));
 const userDataPath = path.join(testRoot, "user-data");
 const port = await reservePort();
@@ -172,9 +188,7 @@ try {
   await waitForDebugEndpoint(debugUrl, child, output);
   browser = await chromium.connectOverCDP(debugUrl);
 
-  const context = browser.contexts()[0];
-  const page = context?.pages()[0];
-  if (!page) throw new Error("Packaged app did not create a renderer page");
+  const page = await waitForRendererPage(browser, child, output);
 
   const pageErrors = [];
   page.on("pageerror", (error) => pageErrors.push(error));


### PR DESCRIPTION
## Summary

- wait for a packaged renderer page after Electron's debug endpoint becomes available
- preserve process output in startup timeout failures

This prevents slower recovery initialization from racing the packaged-app smoke check.

## Issue

No issue — small CI startup-race fix.

## Testing

- `pnpm format:files scripts/smoke-packaged.mjs`
- `node --check scripts/smoke-packaged.mjs`
- `pnpm test:release` (24 passed)
- commit hooks: Oxfmt, Oxlint, dead code, and Vitest passed
- packaged Linux execution not run locally; the hosted Nightly workflow exercises this path

## Evidence

- [Failing Nightly Linux smoke check](https://github.com/shift-editor/shift/actions/runs/33383840505/job/99461937345)
