### PR TITLE
ci: cache Rust artifacts in Nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,6 +131,9 @@ jobs:
       - name: Install Rust toolchain
         run: rustup show
 
+      - name: Restore Rust build cache
+        uses: Swatinem/rust-cache@v2
+
       - name: Install Linux maker tools
         if: matrix.platform == 'linux'
         run: sudo apt-get update && sudo apt-get install --yes fakeroot rpm xvfb


### PR DESCRIPTION
## Summary

- restore Cargo dependency artifacts before each Nightly native build
- persist platform- and toolchain-specific caches through `Swatinem/rust-cache`

## Issue

No issue — small CI build-time maintenance.

## Testing

- `nix run nixpkgs#actionlint -- -shellcheck= .github/workflows/nightly.yml`
- `git diff --check origin/main...HEAD`
- commit hooks: YAML validation passed
- Full `actionlint` reports the pre-existing SC2035 warning for `sha256sum *`; the same warning is present on `main`
- Not run: hosted cache round-trip; the first Nightly run will populate each platform cache and a subsequent run will verify reuse
