### PR TITLE
refactor(catalog): define renderer contract

### DIFF
--- a/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
+++ b/apps/desktop/src/renderer/src/components/home/GlyphCatalogCanvas.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
-import { GlyphCatalogController } from "./GlyphCatalogController";
+import { SlugGlyphCatalogRenderer } from "./SlugGlyphCatalogRenderer";
 import { GlyphNameInput } from "./GlyphNameInput";
 import { useTheme } from "@/context/ThemeContext";
 import type {
@@ -7,6 +7,7 @@ import type {
   GlyphCatalogItem,
   PendingGlyphNames,
 } from "@/types/glyphCatalog";
+import type { GlyphCatalogRenderer } from "@/types/glyphCatalogRenderer";
 import { useFontSession } from "@/workspace/WorkspaceContext";
 import { effect, track } from "@/lib/signals";
 
@@ -45,7 +46,7 @@ export function GlyphCatalogCanvas({
   const overlayCanvasRef = useRef<HTMLCanvasElement>(null);
   const inputContainerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const controllerRef = useRef<GlyphCatalogController | null>(null);
+  const rendererRef = useRef<GlyphCatalogRenderer | null>(null);
   const [ready, setReady] = useState(false);
   const [editingGlyph, setEditingGlyph] = useState<GlyphCatalogItem | null>(null);
   const [pendingGlyphNames, setPendingGlyphNames] = useState<PendingGlyphNames>(() => new Map());
@@ -56,7 +57,7 @@ export function GlyphCatalogCanvas({
     const overlayCanvas = overlayCanvasRef.current;
     if (!container || !glyphCanvas || !overlayCanvas) return undefined;
 
-    const controller = new GlyphCatalogController(
+    const renderer = new SlugGlyphCatalogRenderer(
       container,
       glyphCanvas,
       overlayCanvas,
@@ -78,11 +79,11 @@ export function GlyphCatalogCanvas({
       },
       onUnavailable,
     );
-    controllerRef.current = controller;
+    rendererRef.current = renderer;
 
     return () => {
-      controllerRef.current = null;
-      controller.destroy();
+      rendererRef.current = null;
+      renderer.destroy();
     };
   }, [
     atlasSource,
@@ -95,7 +96,7 @@ export function GlyphCatalogCanvas({
   ]);
 
   useLayoutEffect(() => {
-    controllerRef.current?.update(
+    rendererRef.current?.update(
       {
         glyphs: glyphs.map((glyph) =>
           pendingGlyphNames.has(glyph.id)

--- a/apps/desktop/src/renderer/src/components/home/SlugGlyphCatalogRenderer.ts
+++ b/apps/desktop/src/renderer/src/components/home/SlugGlyphCatalogRenderer.ts
@@ -15,13 +15,15 @@ import type {
 } from "@/types/glyphCatalog";
 import type { GlyphPreviewInstance } from "@/types/glyphPreview";
 import type { GlyphAtlasPageRequest, GlyphAtlasSource } from "@/types/glyphAtlas";
+import type { GlyphCatalogRenderer } from "@/types/glyphCatalogRenderer";
 
 const ATLAS_PAGE_ROOT_COUNT = 256;
 const SLUG_ATLAS_PROFILING_ENABLED =
   new URLSearchParams(window.location.search).get("shiftProfileSlugAtlas") === "1";
 
-/** Owns catalog DOM events, complete atlas replacement, and frame scheduling. */
-export class GlyphCatalogController {
+/** Owns Slug catalog events, complete atlas replacement, and frame scheduling. */
+export class SlugGlyphCatalogRenderer implements GlyphCatalogRenderer {
+  readonly kind = "slug" as const;
   readonly #container: HTMLDivElement;
   readonly #glyphCanvas: HTMLCanvasElement;
   readonly #atlasSource: GlyphAtlasSource;

--- a/apps/desktop/src/renderer/src/types/glyphCatalogRenderer.ts
+++ b/apps/desktop/src/renderer/src/types/glyphCatalogRenderer.ts
@@ -1,0 +1,20 @@
+import type { GlyphCatalogControllerFrame } from "./glyphCatalog";
+
+export type GlyphCatalogRendererKind = "slug" | "svg";
+
+/** Owns one session-fixed glyph catalog rendering implementation. */
+export interface GlyphCatalogRenderer {
+  readonly kind: GlyphCatalogRendererKind;
+
+  /** Applies the latest catalog frame and optional inline-name input host. */
+  update(frame: GlyphCatalogControllerFrame, inputContainer: HTMLDivElement | null): void;
+
+  /** Releases rendering resources and catalog event subscriptions. Idempotent. */
+  destroy(): void;
+}
+
+/** Couples the selected session renderer with its stable implementation kind. */
+export interface GlyphCatalogRendererSelection {
+  readonly kind: GlyphCatalogRendererKind;
+  readonly renderer: GlyphCatalogRenderer;
+}


### PR DESCRIPTION
## Summary

- define the shared glyph catalog renderer contract and stable renderer kind
- name the existing WebGPU implementation as the Slug renderer without changing behavior
- prepare the catalog shell for session-fixed backend selection

## Issue

Refs #327

## Testing

- `pnpm typecheck`
- commit hooks: Oxfmt, Oxlint, tsgo, deadcode, Vitest
- E2E not run: this prerequisite is a behavior-preserving type and symbol refactor
