### PR TITLE
fix(desktop): share document close transitions

### DIFF
--- a/apps/desktop/src/main/AsyncOnce.test.ts
+++ b/apps/desktop/src/main/AsyncOnce.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { AsyncOnce } from "./AsyncOnce";
+
+describe("AsyncOnce retained work", () => {
+  it("shares the exact promise while work is pending", async () => {
+    const once = new AsyncOnce<number>();
+    let complete!: (result: number) => void;
+    const work = new Promise<number>((resolve) => {
+      complete = resolve;
+    });
+
+    const first = once.run(() => work);
+    const second = once.run(() => 2);
+    complete(1);
+
+    expect(second).toBe(first);
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 1]);
+  });
+
+  it("retains a fulfilled result until reset", async () => {
+    const once = new AsyncOnce<number>();
+    const first = once.run(() => 1);
+    await first;
+
+    const second = once.run(() => 2);
+
+    expect(second).toBe(first);
+    await expect(second).resolves.toBe(1);
+  });
+
+  it("turns a synchronous throw into a retained rejection", async () => {
+    const once = new AsyncOnce<number>();
+    const first = once.run(() => {
+      throw new Error("failed");
+    });
+    const second = once.run(() => 2);
+
+    expect(second).toBe(first);
+    await expect(second).rejects.toThrow("failed");
+  });
+
+  it("retains an asynchronous rejection until reset", async () => {
+    const once = new AsyncOnce<number>();
+    const first = once.run(async () => Promise.reject(new Error("failed")));
+    await expect(first).rejects.toThrow("failed");
+
+    const second = once.run(() => 2);
+
+    expect(second).toBe(first);
+    await expect(second).rejects.toThrow("failed");
+  });
+
+  it("starts fresh work after reset", async () => {
+    const once = new AsyncOnce<number>();
+    const first = once.run(() => 1);
+    once.reset();
+
+    const second = once.run(() => 2);
+
+    expect(second).not.toBe(first);
+    await expect(Promise.all([first, second])).resolves.toEqual([1, 2]);
+  });
+});

--- a/apps/desktop/src/main/AsyncOnce.ts
+++ b/apps/desktop/src/main/AsyncOnce.ts
@@ -1,0 +1,22 @@
+/** Retains one asynchronous result until explicitly reset. */
+export class AsyncOnce<Result> {
+  #promise: Promise<Result> | null = null;
+
+  /**
+   * Starts work when empty and otherwise returns the retained promise.
+   *
+   * @param work - operation retained through pending, fulfilled, or rejected settlement.
+   * @returns the exact retained promise shared by every caller before reset.
+   */
+  run(work: () => Result | PromiseLike<Result>): Promise<Result> {
+    if (this.#promise) return this.#promise;
+
+    this.#promise = Promise.resolve().then(work);
+    return this.#promise;
+  }
+
+  /** Returns the one-shot to empty without altering a retained promise's settlement. */
+  reset(): void {
+    this.#promise = null;
+  }
+}

--- a/apps/desktop/src/main/app/AppLifecycle.test.ts
+++ b/apps/desktop/src/main/app/AppLifecycle.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import type { ShiftLogger } from "../logging";
+import { AppLifecycle, type CloseConfirmation } from "./AppLifecycle";
+
+const silentLogger: ShiftLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+describe("AppLifecycle document close authorization", () => {
+  it("rejects quit confirmation after a workspace close failure", async () => {
+    let closeFails = true;
+    const document: CloseConfirmation = {
+      shouldConfirmClose: () => true,
+      prepareClose: async () => true,
+      commitClose: async () => {
+        if (closeFails) throw new Error("close failed");
+      },
+      cancelClose() {},
+    };
+    const lifecycle = new AppLifecycle({
+      documentForWindow: () => null,
+      documents: () => [document],
+      log: silentLogger,
+    });
+
+    await expect(lifecycle.confirmQuit("update")).rejects.toThrow(
+      "One or more documents could not be closed",
+    );
+    closeFails = false;
+
+    await expect(lifecycle.confirmQuit("update")).resolves.toBe(true);
+  });
+
+  it("awaits every attempted close before rejecting authorization", async () => {
+    let secondClosed = false;
+    const failed: CloseConfirmation = {
+      shouldConfirmClose: () => true,
+      prepareClose: async () => true,
+      commitClose: async () => Promise.reject(new Error("close failed")),
+      cancelClose() {},
+    };
+    const completed: CloseConfirmation = {
+      shouldConfirmClose: () => true,
+      prepareClose: async () => true,
+      commitClose: async () => {
+        await Promise.resolve();
+        secondClosed = true;
+      },
+      cancelClose() {},
+    };
+    const lifecycle = new AppLifecycle({
+      documentForWindow: () => null,
+      documents: () => [failed, completed],
+      log: silentLogger,
+    });
+
+    await expect(lifecycle.confirmQuit("quit")).rejects.toThrow(
+      "One or more documents could not be closed",
+    );
+
+    expect(secondClosed).toBe(true);
+  });
+});

--- a/apps/desktop/src/main/app/AppLifecycle.ts
+++ b/apps/desktop/src/main/app/AppLifecycle.ts
@@ -79,6 +79,7 @@ export class AppLifecycle {
       return confirmed;
     } catch (error) {
       this.#quitState = "idle";
+      this.#log.error("quit preparation failed", { reason, error });
       throw error;
     } finally {
       if (this.#quitConfirmation === confirmation) this.#quitConfirmation = null;
@@ -145,6 +146,7 @@ export class AppLifecycle {
       await document.commitClose();
     } catch (error) {
       this.#log.error("window document close failed after commit", error);
+      return;
     }
 
     this.#log.info("window close committed", { windowId });
@@ -196,10 +198,20 @@ export class AppLifecycle {
     }
 
     const results = await Promise.allSettled(prepared.map((document) => document.commitClose()));
+    const failures: unknown[] = [];
     for (const result of results) {
-      if (result.status === "rejected") {
-        this.#log.error("document close failed after commit", result.reason);
+      switch (result.status) {
+        case "fulfilled":
+          break;
+        case "rejected":
+          failures.push(result.reason);
+          this.#log.error("document close failed after commit", result.reason);
+          break;
       }
+    }
+
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "One or more documents could not be closed");
     }
 
     return true;

--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Main
 
-<!-- reviewed: 2026-08-27 -->
+<!-- reviewed: 2026-09-01 -->
 
 Electron main process: app startup, windows, menus, document dialogs, and workspace session ownership.
 
@@ -13,7 +13,7 @@ Electron main process: app startup, windows, menus, document dialogs, and worksp
 - **Architecture Invariant:** Dirty state and save targets come from the utility-owned workspace state. Main obtains native choices through `NativeDialogs`, but state reads, saves, and exports go through the renderer document lane so pending edits flush first. Production uses Electron dialogs; E2E injects deterministic choices at this outer boundary.
 - **Architecture Invariant:** TTF export snapshots the workspace in the ordered sync lane, then releases that lane before font compilation so subsequent editing is not blocked by fontc.
 - **Architecture Invariant:** Within one app instance, at most one live or in-flight session owns a `DocumentId`. Different documents open concurrently; a raw filesystem copy retains its identity and therefore reuses the existing session until Save As mints an independent `DocumentId`.
-- **Architecture Invariant:** `DocumentSession.prepareClose(reason)` may prompt and save, but it never closes a workspace. Window close prepares and commits its one document. Quit and update restart prepare every document before committing any; cancellation calls `cancelClose()` on every prepared document. `commitClose()` is the point of no return and clears recovery only for an explicit discard.
+- **Architecture Invariant:** `DocumentSession.prepareClose(reason)` may prompt and save, but it never closes a workspace. Overlapping Window Close, Quit, and Restart to Update requests for one document share one retained preparation; the first request owns the reason and native dialog until cancellation, failure, or commit cleanup resets it. Window close prepares and commits its one document. Quit and update restart prepare every document before committing any; cancellation calls `cancelClose()` on every prepared document. Joined `commitClose()` calls share one workspace close, which is the point of no return and clears recovery only for an explicit discard.
 - **Architecture Invariant:** Closing every window keeps the application alive on macOS. Activating the windowless app opens a fresh launcher; Windows and Linux quit after the last window closes.
 - **Architecture Invariant:** Release and Nightly builds have distinct product identities and app-data roots. `Shift` uses `app.shift` and the `Shift` data root; `Shift Nightly` uses `app.shift.nightly` and the `Shift Nightly` data root. An explicit `--user-data-dir` switch takes precedence for tests and diagnostics.
 - **Architecture Invariant:** Shift is single-instance within one distribution data root. Operating-system `.shift` activations received before readiness queue in order; later activations focus an already-open document or create another workspace window. Release owns the document association, while Nightly remains an alternate handler.
@@ -26,6 +26,7 @@ Electron main process: app startup, windows, menus, document dialogs, and worksp
 ```text
 src/main/
   main.ts                         -- Electron entry point
+  AsyncOnce.ts                    -- resettable retained asynchronous one-shot
   release.ts                      -- compiled distribution identity and product name
   about/
     AboutWindow.ts                -- singleton native-framed product information window
@@ -63,6 +64,7 @@ src/main/
 
 ## Key Types
 
+- `AsyncOnce` -- resettable one-shot that retains the exact pending or settled promise until explicit cleanup.
 - `WorkspaceManager` -- registry for live authored documents, immutable preview sessions, and window attachments.
 - `FontSessionHost` -- owns the immutable mode, utility process, optional authored document services, and attached windows for one open font.
 - `DocumentSessionIndex` -- maps each live `DocumentId` to one app-local workspace session and follows Save As identity changes.
@@ -104,7 +106,7 @@ Eligible packaged macOS builds and Windows Nightly x64 builds start `AppUpdater`
 
 `AppUpdater.checkForUpdates(trigger)` derives a fixed HTTPS generic-provider URL from the compiled Release or Nightly distribution and exact platform/architecture. electron-updater reads architecture-specific `latest-mac.yml` on macOS and `latest.yml` for Windows Nightly. It owns numeric version comparison, SHA-512 verification, download, macOS code-signature verification, Authenticode verification when configured, installation, and relaunch. Release and Nightly never share feed paths.
 
-Automatic current/error results stay quiet. When a check finds an update, the native-framed update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
+Automatic current/error results stay quiet. When a check finds an update, the native-framed update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. A preparation or workspace-close failure blocks installation, remains technical in the log, and presents actionable document-save guidance rather than workspace internals. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
 
 The application menu exposes `app.checkForUpdates` under the macOS app menu and the Windows/Linux Help menu. Every platform's Help menu also opens the Shift website, Discord, X account, and GitHub issue form through fixed main-owned URLs. Update behavior remains main-owned and does not add renderer IPC.
 
@@ -128,7 +130,7 @@ Export TrueType follows the same document and sync lanes. The utility process ca
 
 For a document-backed workspace, Save first reconciles the current canonical commit and then commits only its sparse recovery rows. A changed commit becomes `Conflict` rather than accepting a stale Save. Save As snapshots the merged view to a new canonical `DocumentId`, installs a fresh recovery overlay, and rebinds the existing app-local workspace session. The source canonical document remains unchanged.
 
-Close and quit call `DocumentSession.prepareClose`. If the document is clean, the user saves successfully, or the user chooses discard, the session records the close intent without closing the workspace. Once the whole transition is accepted, `commitClose` calls `workspace.close`; an explicit discard first clears native recovery state. The utility then drops the Rust workspace handle, removes the document binding, and deletes the app-owned workspace directory. A crash or forced termination bypasses this cleanup, allowing the next open of the same document address to resume completed recovery transactions.
+Close and quit call `DocumentSession.prepareClose`. The first request retains ownership from state settlement through the native decision and any save; later Window Close, Quit, or Restart to Update requests join that exact result even after it settles but before commit. Cancel and failed preparation reset the transition. If the document is clean, the user saves successfully, or the user chooses discard, the session records the close intent without closing the workspace. Once the whole transition is accepted, joined `commitClose` calls await one `workspace.close`; an explicit discard first clears native recovery state. Completed and failed commit cleanup reset the retained transition. The utility then drops the Rust workspace handle, removes the document binding, and deletes the app-owned workspace directory. A crash or forced termination bypasses this cleanup, allowing the next open of the same document address to resume completed recovery transactions.
 
 Message lanes reject in-flight calls when their remote port closes. An unexpected utility-process exit also disconnects the renderer document lane: Save remains blocked because pending edits cannot be settled, while an explicit Discard treats the unavailable workspace as already closed so window and quit guards can finish.
 
@@ -168,6 +170,7 @@ Renderer IPC in `App` is limited to shell capabilities: command execution, nativ
 - `pnpm --filter @shift/desktop test src/utility/workspace/WorkspaceHost.test.ts`
 - `pnpm --filter @shift/desktop test src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts`
 - `pnpm typecheck`
+- `pnpm test:desktop src/main/AsyncOnce.test.ts src/main/document/DocumentSession.test.ts src/main/app/AppLifecycle.test.ts`
 - `pnpm test:desktop src/main/update/updateFeed.test.ts`
 - `pnpm test:release`
 - Electron E2E fixtures materialize a native startup document under a fresh `testRoot`, launch with a fresh `userDataDir`, assert Electron honored that path, and remove the root after force-closing the disposable process.

--- a/apps/desktop/src/main/document/DocumentSession.test.ts
+++ b/apps/desktop/src/main/document/DocumentSession.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import type { NativeDialogs } from "../dialogs/NativeDialogs";
+import type { ShiftLogger } from "../logging";
+import type { Document } from "./DocumentClient";
+import { DocumentSession } from "./DocumentSession";
+
+const silentLogger: ShiftLogger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+};
+
+function documentState(dirty = true): WorkspaceDocumentState {
+  return {
+    workspaceId: "workspace",
+    sourceKind: "shift",
+    documentId: "document",
+    saveTarget: "/tmp/document.shift",
+    canonicalPath: "/tmp/document.shift",
+    dirty,
+    needsSaveAs: false,
+  };
+}
+
+function nativeDialogs(confirmDirtyDocument: NativeDialogs["confirmDirtyDocument"]): NativeDialogs {
+  return {
+    async openFont() {
+      return null;
+    },
+    async showCreateFailure() {},
+    async showOpenFailure() {},
+    async saveShiftDocument() {
+      return null;
+    },
+    async exportTrueTypeFont() {
+      return null;
+    },
+    confirmDirtyDocument,
+    async confirmDocumentReopen() {
+      return "close";
+    },
+    async showSaveFailure() {},
+    async showExportFailure() {},
+  };
+}
+
+describe("DocumentSession shared close transition", () => {
+  it("shares one save decision and one workspace close", async () => {
+    let dialogCount = 0;
+    let saveCount = 0;
+    let closeCount = 0;
+    let workspaceOpen = true;
+    let chooseSave!: () => void;
+    let finishClose!: () => void;
+    const choice = new Promise<void>((resolve) => (chooseSave = resolve));
+    const closing = new Promise<void>((resolve) => (finishClose = resolve));
+    const document: Document = {
+      get connected() {
+        return workspaceOpen;
+      },
+      async state() {
+        if (!workspaceOpen) throw new Error("invalid workspace: no workspace is open");
+        return documentState();
+      },
+      async save() {
+        if (!workspaceOpen) throw new Error("invalid workspace: no workspace is open");
+        saveCount++;
+        return documentState(false);
+      },
+      async export() {
+        throw new Error("unused");
+      },
+    };
+    const session = new DocumentSession({
+      document,
+      closeDocument: async () => {
+        closeCount++;
+        await closing;
+        workspaceOpen = false;
+      },
+      dialogWindow: () => null,
+      windows: () => [],
+      applicationName: () => "Shift",
+      nativeDialogs: nativeDialogs(async (_window, _state, reason) => {
+        dialogCount++;
+        expect(reason).toBe("window");
+        await choice;
+        return "save";
+      }),
+      log: silentLogger,
+    });
+
+    const windowClose = session.prepareClose("window");
+    const updateClose = session.prepareClose("update");
+    chooseSave();
+    await expect(Promise.all([windowClose, updateClose])).resolves.toEqual([true, true]);
+    const firstCommit = session.commitClose();
+    const secondCommit = session.commitClose();
+    finishClose();
+    await Promise.all([firstCommit, secondCommit]);
+
+    expect({ dialogCount, saveCount, closeCount, workspaceOpen }).toEqual({
+      dialogCount: 1,
+      saveCount: 1,
+      closeCount: 1,
+      workspaceOpen: false,
+    });
+  });
+
+  it("retains a discard decision after preparation settles", async () => {
+    let dialogCount = 0;
+    let closeCount = 0;
+    const session = new DocumentSession({
+      document: {
+        connected: true,
+        async state() {
+          return documentState();
+        },
+        async save() {
+          throw new Error("save must not run for discard");
+        },
+        async export() {
+          throw new Error("unused");
+        },
+      },
+      closeDocument: async (discard) => {
+        expect(discard).toBe(true);
+        closeCount++;
+      },
+      dialogWindow: () => null,
+      windows: () => [],
+      applicationName: () => "Shift",
+      nativeDialogs: nativeDialogs(async () => {
+        dialogCount++;
+        return "discard";
+      }),
+      log: silentLogger,
+    });
+
+    await expect(session.prepareClose("window")).resolves.toBe(true);
+    await expect(session.prepareClose("update")).resolves.toBe(true);
+    await Promise.all([session.commitClose(), session.commitClose()]);
+
+    expect({ dialogCount, closeCount }).toEqual({ dialogCount: 1, closeCount: 1 });
+  });
+
+  it("returns one cancel outcome to every requester and resets", async () => {
+    let dialogCount = 0;
+    let choice: "cancel" | "discard" = "cancel";
+    const session = new DocumentSession({
+      document: {
+        connected: true,
+        async state() {
+          return documentState();
+        },
+        async save() {
+          throw new Error("save must not run");
+        },
+        async export() {
+          throw new Error("unused");
+        },
+      },
+      closeDocument: async () => {},
+      dialogWindow: () => null,
+      windows: () => [],
+      applicationName: () => "Shift",
+      nativeDialogs: nativeDialogs(async () => {
+        dialogCount++;
+        return choice;
+      }),
+      log: silentLogger,
+    });
+
+    const windowClose = session.prepareClose("window");
+    const updateClose = session.prepareClose("update");
+    await expect(Promise.all([windowClose, updateClose])).resolves.toEqual([false, false]);
+    choice = "discard";
+    await expect(session.prepareClose("quit")).resolves.toBe(true);
+
+    expect(dialogCount).toBe(2);
+  });
+
+  it("resets after preparation and workspace close failures", async () => {
+    let dialogFails = true;
+    let closeFails = true;
+    let dialogCount = 0;
+    const session = new DocumentSession({
+      document: {
+        connected: true,
+        async state() {
+          return documentState();
+        },
+        async save() {
+          throw new Error("save must not run");
+        },
+        async export() {
+          throw new Error("unused");
+        },
+      },
+      closeDocument: () => {
+        if (closeFails) throw new Error("close failed");
+        return Promise.resolve();
+      },
+      dialogWindow: () => null,
+      windows: () => [],
+      applicationName: () => "Shift",
+      nativeDialogs: nativeDialogs(async () => {
+        dialogCount++;
+        if (dialogFails) throw new Error("dialog failed");
+        return "discard";
+      }),
+      log: silentLogger,
+    });
+
+    await expect(session.prepareClose("window")).rejects.toThrow("dialog failed");
+    dialogFails = false;
+    await expect(session.prepareClose("update")).resolves.toBe(true);
+    await expect(session.commitClose()).rejects.toThrow("close failed");
+    closeFails = false;
+    await expect(session.prepareClose("quit")).resolves.toBe(true);
+    await expect(session.commitClose()).resolves.toBeUndefined();
+
+    expect(dialogCount).toBe(3);
+  });
+});

--- a/apps/desktop/src/main/document/DocumentSession.ts
+++ b/apps/desktop/src/main/document/DocumentSession.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { WorkspaceDocumentState } from "../../shared/workspace/protocol";
+import { AsyncOnce } from "../AsyncOnce";
 import type { NativeDialogs } from "../dialogs/NativeDialogs";
 import type { Window } from "../windows/Window";
 import type { Document } from "./DocumentClient";
@@ -37,6 +38,9 @@ export class DocumentSession {
 
   #state: WorkspaceDocumentState | null = null;
   #pendingCloseDiscard: PendingCloseDiscard = null;
+  #closePreparation = new AsyncOnce<boolean>();
+  #closePreparationOwnerReason: CloseReason | null = null;
+  #closeCommit: Promise<void> | null = null;
 
   constructor(options: DocumentSessionOptions) {
     this.#document = options.document;
@@ -62,75 +66,134 @@ export class DocumentSession {
   /**
    * Prompts and saves as needed, recording close intent without closing the workspace.
    *
-   * @param reason - Native transition that would close the document.
+   * @param requestReason - Native transition requesting the shared document close.
    * @returns `true` when the transition may commit.
    * @throws {Error} when the renderer cannot provide a settled document state.
    */
-  async prepareClose(reason: CloseReason): Promise<boolean> {
-    this.#pendingCloseDiscard = null;
-    this.#log.info("close preparation started", {
-      reason,
-      connected: this.#document.connected,
-      cachedDirty: this.#state?.dirty ?? null,
+  async prepareClose(requestReason: CloseReason): Promise<boolean> {
+    if (this.#closePreparationOwnerReason === null) {
+      this.#closePreparationOwnerReason = requestReason;
+      this.#log.info("close preparation started", {
+        ownerReason: requestReason,
+        requestReason,
+        connected: this.#document.connected,
+        cachedDirty: this.#state?.dirty ?? null,
+      });
+    } else {
+      this.#log.info("close preparation joined", {
+        ownerReason: this.#closePreparationOwnerReason,
+        requestReason,
+      });
+    }
+
+    const ownerReason = this.#closePreparationOwnerReason;
+    const preparation = this.#closePreparation.run(async () => {
+      const state = await this.#closeState();
+      if (!state) {
+        this.#log.info("close preparation allowed: no document state", {
+          ownerReason,
+          requestReason: ownerReason,
+        });
+        return true;
+      }
+
+      if (!state.dirty) {
+        this.#pendingCloseDiscard = false;
+        this.#log.info("close preparation complete: document is clean", {
+          ownerReason,
+          requestReason: ownerReason,
+        });
+        return true;
+      }
+
+      const choice = await this.#nativeDialogs.confirmDirtyDocument(
+        this.#dialogWindow(),
+        state,
+        ownerReason,
+        this.#applicationName(),
+      );
+      this.#log.info("dirty document decision received", {
+        ownerReason,
+        requestReason: ownerReason,
+        choice,
+        saveTarget: state.saveTarget,
+        needsSaveAs: state.needsSaveAs,
+      });
+
+      if (choice === "cancel") {
+        this.#log.info("close preparation canceled by user", {
+          ownerReason,
+          requestReason: ownerReason,
+        });
+        return false;
+      }
+
+      if (choice === "discard") {
+        this.#pendingCloseDiscard = true;
+        this.#log.info("close preparation complete: changes discarded", {
+          ownerReason,
+          requestReason: ownerReason,
+        });
+        return true;
+      }
+
+      this.#log.info("close document save started", {
+        ownerReason,
+        requestReason: ownerReason,
+      });
+      const saved = await this.#saveDirtyDocument(state, ownerReason);
+      if (saved) this.#pendingCloseDiscard = false;
+      this.#log.info(saved ? "close document save completed" : "close preparation blocked", {
+        ownerReason,
+        requestReason: ownerReason,
+      });
+      return saved;
     });
 
-    const state = await this.#closeState();
-    if (!state) {
-      this.#log.info("close preparation allowed: no document state", { reason });
-      return true;
+    try {
+      const prepared = await preparation;
+      if (!prepared) {
+        this.#pendingCloseDiscard = null;
+        this.#closePreparationOwnerReason = null;
+        this.#closePreparation.reset();
+      }
+      return prepared;
+    } catch (error) {
+      this.#pendingCloseDiscard = null;
+      this.#closePreparationOwnerReason = null;
+      this.#closePreparation.reset();
+      throw error;
     }
-
-    if (!state.dirty) {
-      this.#pendingCloseDiscard = false;
-      this.#log.info("close preparation complete: document is clean", { reason });
-      return true;
-    }
-
-    const choice = await this.#nativeDialogs.confirmDirtyDocument(
-      this.#dialogWindow(),
-      state,
-      reason,
-      this.#applicationName(),
-    );
-    this.#log.info("dirty document dialog completed", {
-      reason,
-      choice,
-      saveTarget: state.saveTarget,
-      needsSaveAs: state.needsSaveAs,
-    });
-
-    if (choice === "cancel") {
-      this.#log.info("close guard canceled by user", { reason });
-      return false;
-    }
-
-    if (choice === "discard") {
-      this.#pendingCloseDiscard = true;
-      this.#log.info("close preparation complete: changes discarded", { reason });
-      return true;
-    }
-
-    const saved = await this.#saveDirtyDocument(state);
-    if (saved) this.#pendingCloseDiscard = false;
-    this.#log.info(
-      saved ? "close preparation complete: document saved" : "close preparation blocked",
-      { reason },
-    );
-    return saved;
   }
 
-  /** Closes the prepared workspace. Calling this method is the point of no return. */
+  /** Closes the prepared workspace once. Calling this method is the point of no return. */
   async commitClose(): Promise<void> {
-    if (this.#pendingCloseDiscard === null) return;
+    if (this.#closeCommit) return this.#closeCommit;
 
     const discard = this.#pendingCloseDiscard;
-    this.#pendingCloseDiscard = null;
-    await this.#closeDocument(discard);
+    if (discard === null) {
+      this.#closePreparationOwnerReason = null;
+      this.#closePreparation.reset();
+      return;
+    }
+
+    const ownerReason = this.#closePreparationOwnerReason;
+    this.#log.info("workspace close started", {
+      ownerReason,
+      requestReason: ownerReason,
+      discard,
+    });
+    this.#closeCommit = this.#commitWorkspaceClose(discard, ownerReason);
+    return this.#closeCommit;
   }
 
   /** Clears prepared close intent when any document vetoes the transition. */
   cancelClose(): void {
+    if (this.#closeCommit) return;
+
     this.#pendingCloseDiscard = null;
+    this.#closePreparationOwnerReason = null;
+    this.#closePreparation.reset();
   }
 
   /** Runs Save, escalating to Save As when the document has no target yet. */
@@ -235,6 +298,32 @@ export class DocumentSession {
     this.#updateWindowTitle();
   }
 
+  async #commitWorkspaceClose(discard: boolean, ownerReason: CloseReason | null): Promise<void> {
+    await Promise.resolve();
+
+    try {
+      await this.#closeDocument(discard);
+      this.#log.info("workspace close completed", {
+        ownerReason,
+        requestReason: ownerReason,
+        discard,
+      });
+    } catch (error) {
+      this.#log.error("workspace close failed", {
+        ownerReason,
+        requestReason: ownerReason,
+        discard,
+        error,
+      });
+      throw error;
+    } finally {
+      this.#pendingCloseDiscard = null;
+      this.#closePreparationOwnerReason = null;
+      this.#closePreparation.reset();
+      this.#closeCommit = null;
+    }
+  }
+
   async #saveToNewPath(state: WorkspaceDocumentState): Promise<WorkspaceDocumentState | null> {
     const savePath = await this.#nativeDialogs.saveShiftDocument(
       this.#dialogWindow(),
@@ -249,14 +338,21 @@ export class DocumentSession {
     return this.#requestSave(savePath);
   }
 
-  async #saveDirtyDocument(state: WorkspaceDocumentState): Promise<boolean> {
+  async #saveDirtyDocument(
+    state: WorkspaceDocumentState,
+    ownerReason: CloseReason,
+  ): Promise<boolean> {
     try {
       const saved = state.needsSaveAs
         ? await this.#saveToNewPath(state)
         : await this.#requestSave(null);
       return saved !== null;
     } catch (error) {
-      this.#log.warn("dirty document save failed", error);
+      this.#log.warn("close document save failed", {
+        ownerReason,
+        requestReason: ownerReason,
+        error,
+      });
       await this.#nativeDialogs.showSaveFailure(
         this.#dialogWindow(),
         this.#applicationName(),

--- a/apps/desktop/src/main/update/AppUpdater.ts
+++ b/apps/desktop/src/main/update/AppUpdater.ts
@@ -172,21 +172,25 @@ export class AppUpdater {
     if (this.#status.type !== "ready") return;
 
     try {
-      if (!(await this.#options.lifecycle.confirmQuit("update"))) return;
+      if (!(await this.#options.lifecycle.confirmQuit("update"))) {
+        this.#options.log.info("update restart blocked by document close");
+        return;
+      }
     } catch (error) {
-      this.#options.log.warn("documents could not be prepared for update", error);
+      this.#options.log.warn("update restart blocked by document close failure", error);
       await this.#showMessage({
         type: "error",
         buttons: ["OK"],
         title: app.name,
-        message: `${app.name} couldn't restart to update.`,
-        detail: errorToMessage(error),
+        message: "The update was not installed.",
+        detail: "Review and save your open documents, then try restarting to update again.",
       });
       return;
     }
 
     this.#status = { type: "restarting" };
     this.#updateWindow.close();
+    this.#options.log.info("update installation beginning");
     try {
       autoUpdater.quitAndInstall(false, true);
     } catch (error) {


### PR DESCRIPTION
## Summary

- retain one document-close preparation across Window Close, Quit, and Restart to Update so overlapping requests share the first native decision
- make joined commits await one workspace close and reject quit authorization when any close fails
- block update installation on close failure, preserve technical logs, and show actionable failure copy instead of workspace internals
- add recurrence coverage for retained async work, overlapping decisions, post-resolution joins, close-once behavior, and failure cleanup

## Issue

Closes #337

## Testing

Passed:

- `pnpm test:desktop src/main/AsyncOnce.test.ts src/main/document/DocumentSession.test.ts src/main/app/AppLifecycle.test.ts`
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' sh -c 'fluxbox >/tmp/shift-fluxbox.log 2>&1 & sleep 1; exec pnpm test:e2e:platform e2e/application-quit.spec.ts'`

Checked with warnings:

- `python3 scripts/context-drift-check.py` reports 11 existing review-date warnings outside the updated main-process documentation; the changed main documentation is current.

Not run:

- installed Shift Nightly N → N+1 Restart to Update verification with native dialogs; this requires the separate Mini/Aqua installed-update pass
- visual and GPU projects; this change affects native document lifecycle rather than renderer appearance or GPU output

## Follow-up

- #335 tracks making active logs and structured, privacy-aware problem reporting discoverable from Help.
