### PR TITLE
fix(desktop): add more tooltips

### DIFF
--- a/.agents/skills/ui/SKILL.md
+++ b/.agents/skills/ui/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ui
+description: Design, implement, audit, or review Shift user interfaces and shared UI components. Use for React components, Base UI primitives, Tailwind styling or theme tokens, Figma/reference matching, accessibility, icon-only actions, tooltips, menus, popovers, dialogs, forms, layout, and visible UI regressions.
+---
+
+# /ui — Shift Interface Work
+
+Build interfaces that match the supplied design, use Shift's shared primitives and semantic theme, and remain accessible in every interaction state.
+
+## Sources of truth
+
+Read these before editing an unfamiliar UI surface:
+
+1. `docs/architecture/index.md` for documentation routing.
+2. `packages/ui/docs/DOCS.md` for the shared component boundary.
+3. `apps/desktop/src/renderer/index.css` for Tailwind v4 theme tokens, fonts, and custom utilities.
+4. The relevant existing component and its neighboring components for local composition and density.
+5. Any supplied Figma frame, screenshot, or product reference. Treat it as the visual target, not merely inspiration.
+
+When library behavior or composition is unclear, inspect the installed Base UI types and current Base UI documentation. Do not guess from Radix, shadcn, or an older Base UI API.
+
+## Architecture boundary
+
+- Check whether Base UI has a matching primitive before implementing an interactive control.
+- Shared primitives live in `packages/ui/src/components/{component}/` and wrap `@base-ui-components/react/{component}`.
+- Application code imports shared controls from `@shift/ui`; never import Base UI directly in the desktop app.
+- Keep application state and domain behavior in the consuming app. Shared wrappers own primitive composition, reusable visual defaults, and widget-local behavior only.
+- Use the Base UI component name for its Shift wrapper: `Button`, `Menu`, `Popover`, `Tooltip`, and so on.
+- Re-export every shared component and public prop type through its component barrel and `packages/ui/src/index.ts`.
+- Prefer `React.ComponentPropsWithoutRef`, `React.ElementRef`, and `React.forwardRef` so wrappers preserve the primitive contract. Set `displayName` on forwarded components.
+- Compose Base UI triggers with its `render` prop. Produce exactly one interactive DOM element: no nested buttons, no trigger-only wrapper spans, and no duplicated event targets.
+- Use Base UI state attributes such as `data-[disabled]`, `data-[highlighted]`, `data-[active]`, and `data-[starting-style]` instead of duplicating primitive state in React.
+
+## Tailwind and theme tokens
+
+Shift uses Tailwind CSS v4. The renderer theme is declared in the `@theme` block in `apps/desktop/src/renderer/index.css`, and that stylesheet scans shared UI source with:
+
+```css
+@source "../../../../packages/ui/src/**/*.tsx";
+```
+
+Follow these rules:
+
+- Use semantic theme utilities before raw Tailwind palette colors or literals: `bg-surface`, `bg-panel`, `bg-input`, `bg-hover`, `text-primary`, `text-secondary`, `text-muted`, `border-line-subtle`, `ring-accent`, and related tokens.
+- Remember that Shift overrides Tailwind's typography scale: `text-sm` is 12px, `text-ui` is 11px, and `text-xs` is 10px. Check the theme instead of assuming Tailwind defaults.
+- Use opacity modifiers on semantic tokens when appropriate, such as `bg-hover/50`.
+- Do not copy legacy hard-coded hex values or generic palette classes when an existing semantic token expresses the role.
+- Add a new theme token only for a stable semantic role that will be reused or themed. Name the role, not the component or current color.
+- Reserve literal colors and inline styles for genuinely data-driven graphics, canvas/SVG rendering, or platform-defined colors such as native window controls.
+- Use `cn` from `@shift/ui` or the package-local utility for conditional classes and consumer overrides. Shared wrappers must merge `className` through `cn` so `tailwind-merge` resolves conflicts.
+- Keep reusable visual defaults in the shared wrapper. Do not restyle the same primitive independently at many call sites.
+
+## Matching a visual reference
+
+Before changing styles, identify the reference's:
+
+- typography and density;
+- foreground, background, border, and shadow roles;
+- spacing, dimensions, radius, and alignment;
+- hover, focus, pressed, selected, disabled, read-only, open, error, and empty states;
+- popup side, offset, collision behavior, layering, and arrow treatment.
+
+Map those roles to existing theme tokens first. Compare the finished implementation with the reference at the app's actual scale. Do not declare a match from class names alone.
+
+If the reference is ambiguous or conflicts with an established interaction pattern, ask which behavior wins before inventing a new one.
+
+## Accessibility and interaction
+
+- Every icon-only action needs an accessible name and a concise visible tooltip.
+- Tooltip text always names the action. Keep the same tooltip and accessible name when the action is unavailable; disabled styling and behavior communicate availability without replacing the action name with an explanation.
+- If an unavailable control must retain its tooltip, use `aria-disabled`, guard its action, and style that state. Do not use native `disabled`, which removes focus and pointer interaction.
+- Preserve keyboard navigation supplied by Base UI. Verify `focus-visible`, not only pointer hover.
+- Use semantic roles and labels for toolbars, navigation, dialogs, groups, sliders, and form controls.
+- Keep focus indicators visible. Do not remove outlines without an equivalent token-based focus treatment.
+- Portal popups above application content and give their positioner the shared layering class.
+- Close, menu, popover, and dialog triggers are actions too; icon-only compound triggers follow the same label and tooltip rules.
+
+## Coverage audits
+
+For broad UI work such as "add all missing tooltips," do not patch only the first reported control.
+
+1. Define the invariant being audited, such as “every icon-only user action has an accessible name and tooltip.”
+2. Trace the actual component tree for every requested surface.
+3. Search by primitive (`Button`, `MenuTrigger`, `PopoverTrigger`, `DialogClose`, toolbar controls), icon names, and accessible labels. A single grep pattern is not a complete audit.
+4. Include persistent and hover-revealed controls, compound triggers, read-only or disabled states, dialogs, and both home and editor views.
+5. Record a temporary coverage ledger while working: surface, control, shared owner, enabled state, unavailable state, accessible label, and tooltip copy.
+6. Centralize repeated behavior in the narrowest existing shared component when that removes omissions without hiding domain-specific copy.
+7. Recheck the complete inventory after edits. Do not equate “wrapper exists in source” with “tooltip works in the rendered app”; verify compound trigger composition and the active build.
+
+## Testing and review evidence
+
+Test observable behavior, not styling implementation:
+
+- Do not add unit or E2E tests that assert Tailwind classes, static tooltip wiring, component nesting, or Base UI behavior.
+- Add tests when Shift adds meaningful behavior: unavailable controls remain tooltip-accessible, keyboard interaction changes state, focus is restored, a form validates, or a menu action changes application state.
+- For thin wrappers, typechecking plus focused visual/manual verification is usually the right evidence.
+- For materially visible work, capture the actual implementation in each affected state for review. Use the remote E2E workflow when automated Electron verification is warranted; do not open Electron on the user's current Mac.
+- Never update a visual baseline without inspecting the diff and confirming it matches the intended design.
+
+## Validation
+
+Run the smallest relevant checks, then the shared checks for cross-cutting UI changes:
+
+```bash
+pnpm format:files <changed files...>
+pnpm lint:check
+pnpm typecheck
+```
+
+Run repository commands inside the Nix dev shell as required by `AGENTS.md`. If behavior changed, run the focused owning test. If only visual defaults or declarative wiring changed, report the focused manual verification instead of inventing a low-value test.
+
+## Completion checklist
+
+- [ ] Supplied reference matched at actual application scale.
+- [ ] Existing Base UI primitive and `@shift/ui` wrapper used.
+- [ ] Exactly one interactive element per composed trigger.
+- [ ] Semantic theme tokens used; no avoidable raw colors.
+- [ ] Pointer, keyboard, disabled/read-only, and open states considered.
+- [ ] Icon-only actions have accessible names and tooltips.
+- [ ] Requested surfaces were audited completely, not sampled.
+- [ ] Shared styling lives in the shared wrapper.
+- [ ] Formatting, lint, and typecheck pass.
+- [ ] Visible changes have appropriate manual or screenshot evidence.

--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ui
+description: Design, implement, audit, or review Shift user interfaces and shared UI components. Use for React components, Base UI primitives, Tailwind styling or theme tokens, Figma/reference matching, accessibility, icon-only actions, tooltips, menus, popovers, dialogs, forms, layout, and visible UI regressions.
+---
+
+# /ui — Shift Interface Work
+
+Build interfaces that match the supplied design, use Shift's shared primitives and semantic theme, and remain accessible in every interaction state.
+
+## Sources of truth
+
+Read these before editing an unfamiliar UI surface:
+
+1. `docs/architecture/index.md` for documentation routing.
+2. `packages/ui/docs/DOCS.md` for the shared component boundary.
+3. `apps/desktop/src/renderer/index.css` for Tailwind v4 theme tokens, fonts, and custom utilities.
+4. The relevant existing component and its neighboring components for local composition and density.
+5. Any supplied Figma frame, screenshot, or product reference. Treat it as the visual target, not merely inspiration.
+
+When library behavior or composition is unclear, inspect the installed Base UI types and current Base UI documentation. Do not guess from Radix, shadcn, or an older Base UI API.
+
+## Architecture boundary
+
+- Check whether Base UI has a matching primitive before implementing an interactive control.
+- Shared primitives live in `packages/ui/src/components/{component}/` and wrap `@base-ui-components/react/{component}`.
+- Application code imports shared controls from `@shift/ui`; never import Base UI directly in the desktop app.
+- Keep application state and domain behavior in the consuming app. Shared wrappers own primitive composition, reusable visual defaults, and widget-local behavior only.
+- Use the Base UI component name for its Shift wrapper: `Button`, `Menu`, `Popover`, `Tooltip`, and so on.
+- Re-export every shared component and public prop type through its component barrel and `packages/ui/src/index.ts`.
+- Prefer `React.ComponentPropsWithoutRef`, `React.ElementRef`, and `React.forwardRef` so wrappers preserve the primitive contract. Set `displayName` on forwarded components.
+- Compose Base UI triggers with its `render` prop. Produce exactly one interactive DOM element: no nested buttons, no trigger-only wrapper spans, and no duplicated event targets.
+- Use Base UI state attributes such as `data-[disabled]`, `data-[highlighted]`, `data-[active]`, and `data-[starting-style]` instead of duplicating primitive state in React.
+
+## Tailwind and theme tokens
+
+Shift uses Tailwind CSS v4. The renderer theme is declared in the `@theme` block in `apps/desktop/src/renderer/index.css`, and that stylesheet scans shared UI source with:
+
+```css
+@source "../../../../packages/ui/src/**/*.tsx";
+```
+
+Follow these rules:
+
+- Use semantic theme utilities before raw Tailwind palette colors or literals: `bg-surface`, `bg-panel`, `bg-input`, `bg-hover`, `text-primary`, `text-secondary`, `text-muted`, `border-line-subtle`, `ring-accent`, and related tokens.
+- Remember that Shift overrides Tailwind's typography scale: `text-sm` is 12px, `text-ui` is 11px, and `text-xs` is 10px. Check the theme instead of assuming Tailwind defaults.
+- Use opacity modifiers on semantic tokens when appropriate, such as `bg-hover/50`.
+- Do not copy legacy hard-coded hex values or generic palette classes when an existing semantic token expresses the role.
+- Add a new theme token only for a stable semantic role that will be reused or themed. Name the role, not the component or current color.
+- Reserve literal colors and inline styles for genuinely data-driven graphics, canvas/SVG rendering, or platform-defined colors such as native window controls.
+- Use `cn` from `@shift/ui` or the package-local utility for conditional classes and consumer overrides. Shared wrappers must merge `className` through `cn` so `tailwind-merge` resolves conflicts.
+- Keep reusable visual defaults in the shared wrapper. Do not restyle the same primitive independently at many call sites.
+
+## Matching a visual reference
+
+Before changing styles, identify the reference's:
+
+- typography and density;
+- foreground, background, border, and shadow roles;
+- spacing, dimensions, radius, and alignment;
+- hover, focus, pressed, selected, disabled, read-only, open, error, and empty states;
+- popup side, offset, collision behavior, layering, and arrow treatment.
+
+Map those roles to existing theme tokens first. Compare the finished implementation with the reference at the app's actual scale. Do not declare a match from class names alone.
+
+If the reference is ambiguous or conflicts with an established interaction pattern, ask which behavior wins before inventing a new one.
+
+## Accessibility and interaction
+
+- Every icon-only action needs an accessible name and a concise visible tooltip.
+- Tooltip text always names the action. Keep the same tooltip and accessible name when the action is unavailable; disabled styling and behavior communicate availability without replacing the action name with an explanation.
+- If an unavailable control must retain its tooltip, use `aria-disabled`, guard its action, and style that state. Do not use native `disabled`, which removes focus and pointer interaction.
+- Preserve keyboard navigation supplied by Base UI. Verify `focus-visible`, not only pointer hover.
+- Use semantic roles and labels for toolbars, navigation, dialogs, groups, sliders, and form controls.
+- Keep focus indicators visible. Do not remove outlines without an equivalent token-based focus treatment.
+- Portal popups above application content and give their positioner the shared layering class.
+- Close, menu, popover, and dialog triggers are actions too; icon-only compound triggers follow the same label and tooltip rules.
+
+## Coverage audits
+
+For broad UI work such as "add all missing tooltips," do not patch only the first reported control.
+
+1. Define the invariant being audited, such as “every icon-only user action has an accessible name and tooltip.”
+2. Trace the actual component tree for every requested surface.
+3. Search by primitive (`Button`, `MenuTrigger`, `PopoverTrigger`, `DialogClose`, toolbar controls), icon names, and accessible labels. A single grep pattern is not a complete audit.
+4. Include persistent and hover-revealed controls, compound triggers, read-only or disabled states, dialogs, and both home and editor views.
+5. Record a temporary coverage ledger while working: surface, control, shared owner, enabled state, unavailable state, accessible label, and tooltip copy.
+6. Centralize repeated behavior in the narrowest existing shared component when that removes omissions without hiding domain-specific copy.
+7. Recheck the complete inventory after edits. Do not equate “wrapper exists in source” with “tooltip works in the rendered app”; verify compound trigger composition and the active build.
+
+## Testing and review evidence
+
+Test observable behavior, not styling implementation:
+
+- Do not add unit or E2E tests that assert Tailwind classes, static tooltip wiring, component nesting, or Base UI behavior.
+- Add tests when Shift adds meaningful behavior: unavailable controls remain tooltip-accessible, keyboard interaction changes state, focus is restored, a form validates, or a menu action changes application state.
+- For thin wrappers, typechecking plus focused visual/manual verification is usually the right evidence.
+- For materially visible work, capture the actual implementation in each affected state for review. Use the remote E2E workflow when automated Electron verification is warranted; do not open Electron on the user's current Mac.
+- Never update a visual baseline without inspecting the diff and confirming it matches the intended design.
+
+## Validation
+
+Run the smallest relevant checks, then the shared checks for cross-cutting UI changes:
+
+```bash
+pnpm format:files <changed files...>
+pnpm lint:check
+pnpm typecheck
+```
+
+Run repository commands inside the Nix dev shell as required by `AGENTS.md`. If behavior changed, run the focused owning test. If only visual defaults or declarative wiring changed, report the focused manual verification instead of inventing a low-value test.
+
+## Completion checklist
+
+- [ ] Supplied reference matched at actual application scale.
+- [ ] Existing Base UI primitive and `@shift/ui` wrapper used.
+- [ ] Exactly one interactive element per composed trigger.
+- [ ] Semantic theme tokens used; no avoidable raw colors.
+- [ ] Pointer, keyboard, disabled/read-only, and open states considered.
+- [ ] Icon-only actions have accessible names and tooltips.
+- [ ] Requested surfaces were audited completely, not sampled.
+- [ ] Shared styling lives in the shared wrapper.
+- [ ] Formatting, lint, and typecheck pass.
+- [ ] Visible changes have appropriate manual or screenshot evidence.

--- a/.codex/skills/ui/SKILL.md
+++ b/.codex/skills/ui/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: ui
+description: Design, implement, audit, or review Shift user interfaces and shared UI components. Use for React components, Base UI primitives, Tailwind styling or theme tokens, Figma/reference matching, accessibility, icon-only actions, tooltips, menus, popovers, dialogs, forms, layout, and visible UI regressions.
+---
+
+# /ui — Shift Interface Work
+
+Build interfaces that match the supplied design, use Shift's shared primitives and semantic theme, and remain accessible in every interaction state.
+
+## Sources of truth
+
+Read these before editing an unfamiliar UI surface:
+
+1. `docs/architecture/index.md` for documentation routing.
+2. `packages/ui/docs/DOCS.md` for the shared component boundary.
+3. `apps/desktop/src/renderer/index.css` for Tailwind v4 theme tokens, fonts, and custom utilities.
+4. The relevant existing component and its neighboring components for local composition and density.
+5. Any supplied Figma frame, screenshot, or product reference. Treat it as the visual target, not merely inspiration.
+
+When library behavior or composition is unclear, inspect the installed Base UI types and current Base UI documentation. Do not guess from Radix, shadcn, or an older Base UI API.
+
+## Architecture boundary
+
+- Check whether Base UI has a matching primitive before implementing an interactive control.
+- Shared primitives live in `packages/ui/src/components/{component}/` and wrap `@base-ui-components/react/{component}`.
+- Application code imports shared controls from `@shift/ui`; never import Base UI directly in the desktop app.
+- Keep application state and domain behavior in the consuming app. Shared wrappers own primitive composition, reusable visual defaults, and widget-local behavior only.
+- Use the Base UI component name for its Shift wrapper: `Button`, `Menu`, `Popover`, `Tooltip`, and so on.
+- Re-export every shared component and public prop type through its component barrel and `packages/ui/src/index.ts`.
+- Prefer `React.ComponentPropsWithoutRef`, `React.ElementRef`, and `React.forwardRef` so wrappers preserve the primitive contract. Set `displayName` on forwarded components.
+- Compose Base UI triggers with its `render` prop. Produce exactly one interactive DOM element: no nested buttons, no trigger-only wrapper spans, and no duplicated event targets.
+- Use Base UI state attributes such as `data-[disabled]`, `data-[highlighted]`, `data-[active]`, and `data-[starting-style]` instead of duplicating primitive state in React.
+
+## Tailwind and theme tokens
+
+Shift uses Tailwind CSS v4. The renderer theme is declared in the `@theme` block in `apps/desktop/src/renderer/index.css`, and that stylesheet scans shared UI source with:
+
+```css
+@source "../../../../packages/ui/src/**/*.tsx";
+```
+
+Follow these rules:
+
+- Use semantic theme utilities before raw Tailwind palette colors or literals: `bg-surface`, `bg-panel`, `bg-input`, `bg-hover`, `text-primary`, `text-secondary`, `text-muted`, `border-line-subtle`, `ring-accent`, and related tokens.
+- Remember that Shift overrides Tailwind's typography scale: `text-sm` is 12px, `text-ui` is 11px, and `text-xs` is 10px. Check the theme instead of assuming Tailwind defaults.
+- Use opacity modifiers on semantic tokens when appropriate, such as `bg-hover/50`.
+- Do not copy legacy hard-coded hex values or generic palette classes when an existing semantic token expresses the role.
+- Add a new theme token only for a stable semantic role that will be reused or themed. Name the role, not the component or current color.
+- Reserve literal colors and inline styles for genuinely data-driven graphics, canvas/SVG rendering, or platform-defined colors such as native window controls.
+- Use `cn` from `@shift/ui` or the package-local utility for conditional classes and consumer overrides. Shared wrappers must merge `className` through `cn` so `tailwind-merge` resolves conflicts.
+- Keep reusable visual defaults in the shared wrapper. Do not restyle the same primitive independently at many call sites.
+
+## Matching a visual reference
+
+Before changing styles, identify the reference's:
+
+- typography and density;
+- foreground, background, border, and shadow roles;
+- spacing, dimensions, radius, and alignment;
+- hover, focus, pressed, selected, disabled, read-only, open, error, and empty states;
+- popup side, offset, collision behavior, layering, and arrow treatment.
+
+Map those roles to existing theme tokens first. Compare the finished implementation with the reference at the app's actual scale. Do not declare a match from class names alone.
+
+If the reference is ambiguous or conflicts with an established interaction pattern, ask which behavior wins before inventing a new one.
+
+## Accessibility and interaction
+
+- Every icon-only action needs an accessible name and a concise visible tooltip.
+- Tooltip text always names the action. Keep the same tooltip and accessible name when the action is unavailable; disabled styling and behavior communicate availability without replacing the action name with an explanation.
+- If an unavailable control must retain its tooltip, use `aria-disabled`, guard its action, and style that state. Do not use native `disabled`, which removes focus and pointer interaction.
+- Preserve keyboard navigation supplied by Base UI. Verify `focus-visible`, not only pointer hover.
+- Use semantic roles and labels for toolbars, navigation, dialogs, groups, sliders, and form controls.
+- Keep focus indicators visible. Do not remove outlines without an equivalent token-based focus treatment.
+- Portal popups above application content and give their positioner the shared layering class.
+- Close, menu, popover, and dialog triggers are actions too; icon-only compound triggers follow the same label and tooltip rules.
+
+## Coverage audits
+
+For broad UI work such as "add all missing tooltips," do not patch only the first reported control.
+
+1. Define the invariant being audited, such as “every icon-only user action has an accessible name and tooltip.”
+2. Trace the actual component tree for every requested surface.
+3. Search by primitive (`Button`, `MenuTrigger`, `PopoverTrigger`, `DialogClose`, toolbar controls), icon names, and accessible labels. A single grep pattern is not a complete audit.
+4. Include persistent and hover-revealed controls, compound triggers, read-only or disabled states, dialogs, and both home and editor views.
+5. Record a temporary coverage ledger while working: surface, control, shared owner, enabled state, unavailable state, accessible label, and tooltip copy.
+6. Centralize repeated behavior in the narrowest existing shared component when that removes omissions without hiding domain-specific copy.
+7. Recheck the complete inventory after edits. Do not equate “wrapper exists in source” with “tooltip works in the rendered app”; verify compound trigger composition and the active build.
+
+## Testing and review evidence
+
+Test observable behavior, not styling implementation:
+
+- Do not add unit or E2E tests that assert Tailwind classes, static tooltip wiring, component nesting, or Base UI behavior.
+- Add tests when Shift adds meaningful behavior: unavailable controls remain tooltip-accessible, keyboard interaction changes state, focus is restored, a form validates, or a menu action changes application state.
+- For thin wrappers, typechecking plus focused visual/manual verification is usually the right evidence.
+- For materially visible work, capture the actual implementation in each affected state for review. Use the remote E2E workflow when automated Electron verification is warranted; do not open Electron on the user's current Mac.
+- Never update a visual baseline without inspecting the diff and confirming it matches the intended design.
+
+## Validation
+
+Run the smallest relevant checks, then the shared checks for cross-cutting UI changes:
+
+```bash
+pnpm format:files <changed files...>
+pnpm lint:check
+pnpm typecheck
+```
+
+Run repository commands inside the Nix dev shell as required by `AGENTS.md`. If behavior changed, run the focused owning test. If only visual defaults or declarative wiring changed, report the focused manual verification instead of inventing a low-value test.
+
+## Completion checklist
+
+- [ ] Supplied reference matched at actual application scale.
+- [ ] Existing Base UI primitive and `@shift/ui` wrapper used.
+- [ ] Exactly one interactive element per composed trigger.
+- [ ] Semantic theme tokens used; no avoidable raw colors.
+- [ ] Pointer, keyboard, disabled/read-only, and open states considered.
+- [ ] Icon-only actions have accessible names and tooltips.
+- [ ] Requested surfaces were audited completely, not sampled.
+- [ ] Shared styling lives in the shared wrapper.
+- [ ] Formatting, lint, and typecheck pass.
+- [ ] Visible changes have appropriate manual or screenshot evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 ## Agent Skills
 
 - `.agents/skills/` is the canonical source for repository skills. Pi discovers this standard location automatically.
-- Load the matching skill before acting: `commit` for commits, `pr` for pull requests, `issue` for issues, `writing-tests` for test changes or reviews, `jsdoc` for JSDoc, and `rustdoc` for Rust documentation.
+- Load the matching skill before acting: `commit` for commits, `pr` for pull requests, `issue` for issues, `writing-tests` for test changes or reviews, `ui` for interface and styling work, `jsdoc` for JSDoc, and `rustdoc` for Rust documentation.
 - `.claude/skills/` and `.codex/skills/` are generated client adapters. Never edit shared skills there directly.
 - After changing a canonical skill, run `pnpm agent-skills:sync`. CI runs `pnpm agent-skills:check` to prevent adapter drift.
 

--- a/apps/desktop/e2e/application-quit.spec.ts
+++ b/apps/desktop/e2e/application-quit.spec.ts
@@ -148,7 +148,7 @@ test("keeps authored document state isolated between windows", async ({ electron
   expect((await firstPage.evaluate(() => window.shift?.editor.selection.ids.length)) ?? 0).toBe(1);
   expect(await firstPage.evaluate(() => window.shift?.editor.hover.id)).not.toBeNull();
 
-  await firstPage.getByRole("button", { name: "Display all glyphs" }).click();
+  await firstPage.getByRole("button", { name: "Font overview" }).click();
   await firstPage.waitForURL(/#\/home$/);
   await firstPage.getByRole("button", { name: "Create glyph", exact: true }).click();
   await glyphIdForName(firstPage, "newGlyph.1");

--- a/apps/desktop/e2e/editor.spec.ts
+++ b/apps/desktop/e2e/editor.spec.ts
@@ -112,10 +112,10 @@ test.describe("Editor view", () => {
     await expect(page.getByRole("tooltip")).toHaveText("Rotate 90 degrees clockwise");
 
     const scaleAnchor = glyphProperties(page).getByRole("button", {
-      name: "Top-left scale anchor",
+      name: "Anchor top left",
     });
     await scaleAnchor.hover();
-    await expect(page.getByRole("tooltip")).toHaveText("Top-left scale anchor");
+    await expect(page.getByRole("tooltip")).toHaveText("Anchor top left");
   });
 
   test("keeps advance width text current after a sidebar metrics edit", async ({ page }) => {
@@ -158,7 +158,7 @@ test.describe("Editor view", () => {
     const targetX = Math.round(initialBounds.x) + 25;
     const targetY = Math.round(initialBounds.y) + 30;
 
-    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    await properties.getByLabel("Anchor top left", { exact: true }).click();
     await setInputValue(xInput, targetX);
     await setInputValue(yInput, targetY);
 
@@ -170,7 +170,7 @@ test.describe("Editor view", () => {
     const properties = glyphProperties(page);
     const initialBounds = await selectionBounds(page);
 
-    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    await properties.getByLabel("Anchor top left", { exact: true }).click();
     const scaleInput = properties.getByLabel("Scale factor", { exact: true });
     await setInputValue(scaleInput, 2);
 
@@ -187,7 +187,7 @@ test.describe("Editor view", () => {
   test("keeps rotation and flipping centered regardless of the scale anchor", async ({ page }) => {
     await page.keyboard.press("Meta+a");
     const properties = glyphProperties(page);
-    await properties.getByLabel("Top-left scale anchor", { exact: true }).click();
+    await properties.getByLabel("Anchor top left", { exact: true }).click();
     const initialCenter = await selectionCenter(page);
 
     await properties.getByRole("button", { name: "Rotate 90 degrees clockwise" }).click();

--- a/apps/desktop/e2e/editor.spec.ts
+++ b/apps/desktop/e2e/editor.spec.ts
@@ -98,6 +98,26 @@ test.describe("Editor view", () => {
     await expect(glyphProperties(page).getByText("Boolean", { exact: true })).toBeVisible();
   });
 
+  test("explains icon-only editor actions on hover", async ({ page }) => {
+    const toolbar = page.getByRole("toolbar", { name: "Editor tools" });
+    const selectTool = toolbar.getByRole("button", { name: "Select Tool (V)" });
+    await selectTool.hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Select Tool (V)");
+
+    await page.keyboard.press("Meta+a");
+    const rotate = glyphProperties(page).getByRole("button", {
+      name: "Rotate 90 degrees clockwise",
+    });
+    await rotate.hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Rotate 90 degrees clockwise");
+
+    const scaleAnchor = glyphProperties(page).getByRole("button", {
+      name: "Top-left scale anchor",
+    });
+    await scaleAnchor.hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Top-left scale anchor");
+  });
+
   test("keeps advance width text current after a sidebar metrics edit", async ({ page }) => {
     const properties = glyphProperties(page);
     const advanceInput = properties.getByLabel("Advance width", { exact: true });

--- a/apps/desktop/e2e/font-preview.spec.ts
+++ b/apps/desktop/e2e/font-preview.spec.ts
@@ -184,7 +184,7 @@ test.describe("retained font source Grid preview", () => {
     await page.keyboard.press("Escape");
     await expect(page.getByText("Read-only preview")).toBeHidden();
 
-    await editorSurface.getByLabel("Display all glyphs").click();
+    await editorSurface.getByLabel("Font overview").click();
     await page.waitForURL(/#\/home$/);
     await expect(scrollViewport).toBeVisible({ timeout: 1_000 });
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
@@ -228,7 +228,7 @@ test.describe("retained font source Grid preview", () => {
   test("shows preview font settings with disabled authoring controls", async ({ page }) => {
     await expect.poll(() => page.evaluate(() => window.shiftSession?.mode)).toBe("preview");
 
-    await page.getByLabel(/Display and edit font information/).click();
+    await page.getByRole("button", { name: "Settings" }).click();
     const settingsDialog = page.getByRole("dialog", { name: "Settings" });
     await expect(settingsDialog).toBeVisible();
     await expect(page.getByText("Read-only preview")).toBeHidden();

--- a/apps/desktop/e2e/font-preview.spec.ts
+++ b/apps/desktop/e2e/font-preview.spec.ts
@@ -248,7 +248,10 @@ test.describe("retained font source Grid preview", () => {
       .toBe(true);
 
     await settingsDialog.getByRole("button", { name: "Sources", exact: true }).click();
-    await expect(settingsDialog.getByLabel("Create source")).toBeDisabled();
+    const createSource = settingsDialog.getByLabel("Create source");
+    await expect(createSource).toHaveAttribute("aria-disabled", "true");
+    await createSource.hover();
+    await expect(page.getByRole("tooltip")).toHaveText("Create source");
     const sourceControls = settingsDialog.locator("main input");
     await expect.poll(() => sourceControls.count()).toBeGreaterThan(0);
     await expect

--- a/apps/desktop/e2e/glyph-grid.spec.ts
+++ b/apps/desktop/e2e/glyph-grid.spec.ts
@@ -86,7 +86,7 @@ test.describe("Resident Glyph Grid", () => {
       )
       .toEqual(initialSize);
 
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home/);
     await afterNextPaint(page);
 
@@ -225,7 +225,7 @@ test.describe("Resident Glyph Grid", () => {
       await editor.font.editCoordinator.settled();
     });
 
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home/);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
     await expectCompleteResidency(glyphCanvas);
@@ -271,7 +271,7 @@ test.describe("Resident Glyph Grid", () => {
       await editor.font.editCoordinator.settled();
     });
 
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home/);
     await expect(glyphCanvas).toBeVisible({ timeout: 30_000 });
     await expectCompleteResidency(glyphCanvas);
@@ -393,7 +393,7 @@ test.describe("Resident Glyph Grid", () => {
       if (!inserted) throw new Error("Oversized contour insertion failed");
       await editor.font.editCoordinator.settled();
     });
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home/);
     await expect(glyphCanvas).toHaveAttribute("data-grid-readiness", "Complete", {
       timeout: 30_000,

--- a/apps/desktop/e2e/glyph-navigation.spec.ts
+++ b/apps/desktop/e2e/glyph-navigation.spec.ts
@@ -38,7 +38,7 @@ async function openGlyph(page: Page, glyphId: GlyphId): Promise<void> {
 }
 
 async function returnHome(page: Page): Promise<void> {
-  await page.getByRole("button", { name: "Display all glyphs" }).click();
+  await page.getByRole("button", { name: "Font overview" }).click();
   await page.waitForURL(/#\/home$/);
 }
 

--- a/apps/desktop/e2e/glyph-view.spec.ts
+++ b/apps/desktop/e2e/glyph-view.spec.ts
@@ -66,7 +66,7 @@ test("keeps a useful stable UPM frame across empty and extreme glyphs", async ({
 
   await openGlyphRoute(page, firstGlyph.id);
   const expectedTransform = (await cameraFrame(page)).transform;
-  await page.getByRole("button", { name: "Display all glyphs" }).click();
+  await page.getByRole("button", { name: "Font overview" }).click();
   await page.waitForURL(/#\/home$/);
 
   for (const glyph of glyphs) {
@@ -81,7 +81,7 @@ test("keeps a useful stable UPM frame across empty and extreme glyphs", async ({
       expect(point.y).toBeLessThanOrEqual(frame.viewport.height);
     }
 
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home$/);
   }
 });

--- a/apps/desktop/e2e/home.spec.ts
+++ b/apps/desktop/e2e/home.spec.ts
@@ -85,6 +85,28 @@ test.describe("Home view", () => {
     await expect(surface).toHaveAttribute("data-first-glyph-id", unencoded.id);
   });
 
+  test("explains why source creation is unavailable without axes", async ({ page }) => {
+    await page.evaluate(async () => {
+      const font = window.shift?.font;
+      if (!font) throw new Error("Expected font");
+
+      for (const axis of font.getAxes()) font.deleteAxis(axis.id);
+      await font.editCoordinator.settled();
+    });
+
+    const createSource = page.getByRole("button", { name: "Create source", exact: true });
+    const explanation = page.getByRole("tooltip");
+    await expect(createSource).toHaveAttribute("aria-disabled", "true");
+
+    await createSource.hover();
+    await expect(explanation).toHaveText("Create an axis before adding another source");
+
+    await page.mouse.move(600, 300);
+    await expect(explanation).toBeHidden();
+    await createSource.focus();
+    await expect(explanation).toHaveText("Create an axis before adding another source");
+  });
+
   test("keeps a renamed glyph visible until the catalog confirms its new name", async ({
     page,
   }) => {

--- a/apps/desktop/e2e/home.spec.ts
+++ b/apps/desktop/e2e/home.spec.ts
@@ -85,7 +85,7 @@ test.describe("Home view", () => {
     await expect(surface).toHaveAttribute("data-first-glyph-id", unencoded.id);
   });
 
-  test("explains why source creation is unavailable without axes", async ({ page }) => {
+  test("keeps unavailable source creation discoverable without axes", async ({ page }) => {
     await page.evaluate(async () => {
       const font = window.shift?.font;
       if (!font) throw new Error("Expected font");
@@ -95,16 +95,16 @@ test.describe("Home view", () => {
     });
 
     const createSource = page.getByRole("button", { name: "Create source", exact: true });
-    const explanation = page.getByRole("tooltip");
+    const tooltip = page.getByRole("tooltip");
     await expect(createSource).toHaveAttribute("aria-disabled", "true");
 
     await createSource.hover();
-    await expect(explanation).toHaveText("Create an axis before adding another source");
+    await expect(tooltip).toHaveText("Create source");
 
     await page.mouse.move(600, 300);
-    await expect(explanation).toBeHidden();
+    await expect(tooltip).toBeHidden();
     await createSource.focus();
-    await expect(explanation).toHaveText("Create an axis before adding another source");
+    await expect(tooltip).toHaveText("Create source");
   });
 
   test("keeps a renamed glyph visible until the catalog confirms its new name", async ({
@@ -146,7 +146,7 @@ test.describe("Home view", () => {
 
     await expect(renderer).toBeAttached();
 
-    await page.getByRole("button", { name: "Display all glyphs" }).click();
+    await page.getByRole("button", { name: "Font overview" }).click();
     await page.waitForURL(/#\/home/);
     await afterNextPaint(page);
 

--- a/apps/desktop/e2e/selector-contracts.spec.ts
+++ b/apps/desktop/e2e/selector-contracts.spec.ts
@@ -22,7 +22,7 @@ test("exposes stable semantic selectors for major application surfaces", async (
   await navigation.getByRole("button", { name: "Sources", exact: true }).click();
   await expect(page.getByTestId(`source-${defaultSourceId}`)).toBeVisible();
 
-  await page.getByLabel(/Display and edit font information/).click();
+  await page.getByRole("button", { name: "Settings" }).click();
   const settings = page.getByRole("dialog", { name: "Settings" });
   await expect(settings.getByRole("navigation", { name: "Settings categories" })).toBeVisible();
   await expect(settingsDetails(page)).toBeVisible();

--- a/apps/desktop/e2e/source-font-preview.spec.ts
+++ b/apps/desktop/e2e/source-font-preview.spec.ts
@@ -87,7 +87,7 @@ glyphsPreviewTest("Glyphs sources render a complete resident Grid", async ({ pag
   await expect
     .poll(() => page.evaluate(() => window.shiftSession?.catalog.locationCell.value))
     .not.toEqual(beforeLocation);
-  await editorShell(page).getByLabel("Display all glyphs").click();
+  await editorShell(page).getByLabel("Font overview").click();
   await page.waitForURL(/#\/home$/);
   await expect(glyphCatalogCanvas(page)).toHaveAttribute("data-grid-readiness", "Complete");
   await expect

--- a/apps/desktop/e2e/variable-font-authoring.spec.ts
+++ b/apps/desktop/e2e/variable-font-authoring.spec.ts
@@ -148,7 +148,7 @@ test.describe("variable-font authoring controls", () => {
     if (!defaultSourceName) throw new Error("Expected default source");
     await expect(
       dialog.getByLabel(`Cannot delete ${defaultSourceName}: default source`),
-    ).toBeDisabled();
+    ).toHaveAttribute("aria-disabled", "true");
     await dialog.getByRole("button", { name: "Bold", exact: true }).click();
     const sourceName = main.getByLabel("Name", { exact: true });
     await sourceName.fill("Display Bold");

--- a/apps/desktop/e2e/variable-font-authoring.spec.ts
+++ b/apps/desktop/e2e/variable-font-authoring.spec.ts
@@ -9,7 +9,7 @@ interface VariableFixture {
 }
 
 async function openSettings(page: Page, category: "Axes" | "Sources" | "Instances") {
-  await page.getByLabel(/Display and edit font information/).click();
+  await page.getByRole("button", { name: "Settings" }).click();
   const dialog = page.getByRole("dialog", { name: "Settings" });
   await expect(dialog).toBeVisible();
   await dialog.getByRole("button", { name: category, exact: true }).click();
@@ -146,9 +146,10 @@ test.describe("variable-font authoring controls", () => {
     await selectCategory(dialog, "Sources");
     const defaultSourceName = await page.evaluate(() => window.shift?.font.defaultSource.name);
     if (!defaultSourceName) throw new Error("Expected default source");
-    await expect(
-      dialog.getByLabel(`Cannot delete ${defaultSourceName}: default source`),
-    ).toHaveAttribute("aria-disabled", "true");
+    await expect(dialog.getByLabel(`Delete ${defaultSourceName}`)).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
     await dialog.getByRole("button", { name: "Bold", exact: true }).click();
     const sourceName = main.getByLabel("Name", { exact: true });
     await sourceName.fill("Display Bold");

--- a/apps/desktop/e2e/variable-navigation-glyph-grid.spec.ts
+++ b/apps/desktop/e2e/variable-navigation-glyph-grid.spec.ts
@@ -210,7 +210,7 @@ test("keeps variable preview and exact-source editability coherent across Grid n
     )
     .toBe(400);
 
-  await editorShell(page).getByLabel("Display all glyphs").click();
+  await editorShell(page).getByLabel("Font overview").click();
   await page.waitForURL(/#\/home$/);
   await expect
     .poll(() =>
@@ -251,7 +251,7 @@ test("keeps variable preview and exact-source editability coherent across Grid n
   await expect.poll(() => page.evaluate(() => window.shift?.editor.activeSourceId)).toBeNull();
   await expect(glyphProperties(page).getByLabel("Advance width", { exact: true })).toBeDisabled();
 
-  await editorShell(page).getByLabel("Display all glyphs").click();
+  await editorShell(page).getByLabel("Font overview").click();
   await page.waitForURL(/#\/home$/);
   await openCatalogGlyph(page, "navigationVariable", fixture.firstGlyphId);
   await expectPreview(page, fixture, {

--- a/apps/desktop/src/renderer/index.css
+++ b/apps/desktop/src/renderer/index.css
@@ -33,6 +33,8 @@
   --color-hover: #e5e5e5;
   --color-surface: #ffffff;
   --color-surface-hover: #f5f5f5;
+  --color-surface-inverse: #232323;
+  --color-on-surface-inverse: #ffffff;
   --color-panel: #ffffff;
   --color-input: #ededed;
   --color-icon-button: #f3f3f3;

--- a/apps/desktop/src/renderer/src/app/App.tsx
+++ b/apps/desktop/src/renderer/src/app/App.tsx
@@ -1,6 +1,7 @@
 import "./App.css";
 import { useEffect } from "react";
 import { HashRouter } from "react-router";
+import { TooltipProvider } from "@shift/ui";
 
 import { ThemeProvider } from "@/context/ThemeContext";
 import { FocusZoneProvider } from "@/context/FocusZoneContext";
@@ -30,15 +31,17 @@ export const App = () => {
 
   return (
     <ThemeProvider defaultTheme="light">
-      <ZoomToast>
-        <FocusZoneProvider defaultZone="canvas">
-          <HashRouter>
-            <AppErrorBoundary>
-              <Screens />
-            </AppErrorBoundary>
-          </HashRouter>
-        </FocusZoneProvider>
-      </ZoomToast>
+      <TooltipProvider delayDuration={500}>
+        <ZoomToast>
+          <FocusZoneProvider defaultZone="canvas">
+            <HashRouter>
+              <AppErrorBoundary>
+                <Screens />
+              </AppErrorBoundary>
+            </HashRouter>
+          </FocusZoneProvider>
+        </ZoomToast>
+      </TooltipProvider>
     </ThemeProvider>
   );
 };

--- a/apps/desktop/src/renderer/src/app/routes.ts
+++ b/apps/desktop/src/renderer/src/app/routes.ts
@@ -17,13 +17,13 @@ export const routes: NavRoute[] = [
     kind: "route",
     path: "/home",
     icon: GridSvg,
-    description: "Display all glyphs",
+    description: "Font overview",
   },
   {
     id: "info",
     kind: "dialog",
     dialogId: "settings",
     icon: InfoSvg,
-    description: "Display and edit font information, such as family name, weight, style, etc.",
+    description: "Settings",
   },
 ];

--- a/apps/desktop/src/renderer/src/components/chrome/NavigationPane.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/NavigationPane.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router";
 
-import { Button } from "@shift/ui";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import { routes } from "@/app/routes";
 import { useSettingsNavigation } from "@/context/SettingsNavigationContext";
 
@@ -30,14 +30,20 @@ export const NavigationPane = () => {
             };
 
             return (
-              <Button
-                key={route.id}
-                icon={<Icon width={20} height={20} className="text-primary" />}
-                aria-label={route.description}
-                variant="ghost"
-                size="icon"
-                onClick={onClick}
-              />
+              <Tooltip key={route.id}>
+                <TooltipTrigger>
+                  <Button
+                    icon={<Icon width={20} height={20} className="text-primary" />}
+                    aria-label={route.description}
+                    variant="ghost"
+                    size="icon"
+                    onClick={onClick}
+                  />
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={5}>
+                  {route.description}
+                </TooltipContent>
+              </Tooltip>
             );
           })}
         </div>

--- a/apps/desktop/src/renderer/src/components/chrome/ReadOnlyNoticeDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/ReadOnlyNoticeDialog.tsx
@@ -7,6 +7,9 @@ import {
   DialogPopup,
   DialogPortal,
   DialogTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   X,
   cn,
 } from "@shift/ui";
@@ -55,15 +58,20 @@ export const ReadOnlyNoticeDialog = ({ canConvert }: ReadOnlyNoticeDialogProps) 
               ? "Save this source as a Shift document before making authoring changes."
               : "Compiled TTF and OTF fonts can be inspected here, but this preview cannot be edited or converted."}
           </p>
-          <DialogClose
-            className={cn(
-              "absolute right-2 top-2 inline-flex h-7 w-7 cursor-pointer items-center justify-center",
-              "rounded text-primary/70 transition-colors hover:bg-hover hover:text-primary",
-            )}
-            aria-label="Dismiss read-only notice"
-          >
-            <X className="h-4 w-4" />
-          </DialogClose>
+          <Tooltip>
+            <TooltipTrigger>
+              <DialogClose
+                className={cn(
+                  "absolute right-2 top-2 inline-flex h-7 w-7 cursor-pointer items-center justify-center",
+                  "rounded text-primary/70 transition-colors hover:bg-hover hover:text-primary",
+                )}
+                aria-label="Dismiss read-only notice"
+              >
+                <X className="h-4 w-4" />
+              </DialogClose>
+            </TooltipTrigger>
+            <TooltipContent>Dismiss read-only notice</TooltipContent>
+          </Tooltip>
           <div className="mt-5 flex justify-end">
             <DialogClose render={<Button>OK</Button>} />
           </div>

--- a/apps/desktop/src/renderer/src/components/chrome/ZoomToast.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/ZoomToast.tsx
@@ -6,6 +6,9 @@ import {
   ToastTitle,
   useToastManager,
   Button,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
@@ -102,12 +105,22 @@ function ZoomToastList({ scheduleClose }: { scheduleClose: () => void }) {
       >
         <ToastTitle>{String(toast.title)}</ToastTitle>
         <div className="flex items-center gap-1">
-          <Button variant="ghost" size="icon">
-            <PlusIcon className="w-3 h-3" />
-          </Button>
-          <Button variant="ghost" size="icon">
-            <MinusIcon className="w-3 h-3" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button variant="ghost" size="icon" aria-label="Zoom in">
+                <PlusIcon className="w-3 h-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Zoom in</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button variant="ghost" size="icon" aria-label="Zoom out">
+                <MinusIcon className="w-3 h-3" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Zoom out</TooltipContent>
+          </Tooltip>
           <div className="ml-4">
             <Button variant="primary">Reset</Button>
           </div>

--- a/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
@@ -1,6 +1,16 @@
 import { useEffect, useState } from "react";
 import type { Axis, AxisId } from "@shift/types";
-import { Tabs, TabsIndicator, TabsList, TabsPanel, TabsTab, cn } from "@shift/ui";
+import {
+  Tabs,
+  TabsIndicator,
+  TabsList,
+  TabsPanel,
+  TabsTab,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  cn,
+} from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
 import { SidebarActionButton, SidebarActionRow } from "@/components/sidebar/SidebarActionRow";
@@ -66,17 +76,24 @@ export const AxesSettingsPanel = ({ initialAxisId, canAuthor }: AxesSettingsPane
               onClick={() => setSelectedAxisId(axis.id)}
               contentClassName="h-8 text-sm font-normal"
               actions={
-                <SidebarActionButton
-                  label={`Delete ${axis.name}`}
-                  className="h-8 hover:bg-icon-button-hover"
-                  disabled={!canAuthor}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    font.deleteAxis(axis.id);
-                  }}
-                >
-                  <MinusIcon className="h-3 w-3" />
-                </SidebarActionButton>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <SidebarActionButton
+                      label={`Delete ${axis.name}`}
+                      className="h-8 hover:bg-icon-button-hover"
+                      aria-disabled={!canAuthor || undefined}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (!canAuthor) return;
+
+                        font.deleteAxis(axis.id);
+                      }}
+                    >
+                      <MinusIcon className="h-3 w-3" />
+                    </SidebarActionButton>
+                  </TooltipTrigger>
+                  <TooltipContent>{`Delete ${axis.name}`}</TooltipContent>
+                </Tooltip>
               }
             >
               <span className="truncate">{axis.name}</span>

--- a/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/AxesSettingsPanel.tsx
@@ -57,9 +57,14 @@ export const AxesSettingsPanel = ({ initialAxisId, canAuthor }: AxesSettingsPane
           {canAuthor ? (
             <CreateAxisMenu onAxisCreated={setCreatedAxisId} />
           ) : (
-            <SidebarActionButton label="Create axis" disabled>
-              <PlusIcon className="h-3 w-3" />
-            </SidebarActionButton>
+            <Tooltip>
+              <TooltipTrigger>
+                <SidebarActionButton label="Create axis" aria-disabled="true">
+                  <PlusIcon className="h-3 w-3" />
+                </SidebarActionButton>
+              </TooltipTrigger>
+              <TooltipContent>Create axis</TooltipContent>
+            </Tooltip>
           )}
         </div>
 

--- a/apps/desktop/src/renderer/src/components/chrome/settings/AxisMappingPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/AxisMappingPanel.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import type { Axis, AxisMapping, AxisMappingPoint } from "@shift/types";
 import { mintAxisMappingId } from "@shift/types";
-import { Button } from "@shift/ui";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
 import { useSignalState } from "@/lib/signals";
@@ -110,18 +110,23 @@ export const AxisMappingPanel = ({ axis }: AxisMappingPanelProps) => {
                     onCommit={form.commit}
                   />
                   <td>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-sm"
-                      className="mx-auto h-5 w-5 text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-icon-button-hover"
-                      aria-label={`Remove mapping point ${index + 1}`}
-                      onClick={async () => {
-                        await removePoint(index);
-                      }}
-                    >
-                      <MinusIcon className="h-2.5 w-2.5" />
-                    </Button>
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-sm"
+                          className="mx-auto h-5 w-5 text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-icon-button-hover"
+                          aria-label={`Remove mapping point ${index + 1}`}
+                          onClick={async () => {
+                            await removePoint(index);
+                          }}
+                        >
+                          <MinusIcon className="h-2.5 w-2.5" />
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{`Remove mapping point ${index + 1}`}</TooltipContent>
+                    </Tooltip>
                   </td>
                 </tr>
               ))}

--- a/apps/desktop/src/renderer/src/components/chrome/settings/AxisStylesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/AxisStylesPanel.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import type { Axis, AxisLabel, AxisLabelId } from "@shift/types";
 import { mintAxisLabelId } from "@shift/types";
-import { Button, Checkbox, Input } from "@shift/ui";
+import { Button, Checkbox, Input, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
 import { SettingsNumberField } from "./SettingsNumberField";
@@ -229,21 +229,26 @@ const ElidableCell = ({ label, draft }: { label: AxisLabel; draft: AxisDraft }) 
 
 const RemoveCell = ({ label, draft }: { label: AxisLabel; draft: AxisDraft }) => (
   <td>
-    <Button
-      type="button"
-      variant="ghost"
-      size="icon-sm"
-      className="mx-auto h-5 w-5 text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-icon-button-hover"
-      aria-label={`Remove ${label.name}`}
-      onClick={async () => {
-        await draft.updateAndCommit((axis) => ({
-          ...axis,
-          labels: axis.labels.filter((item) => item.id !== label.id),
-        }));
-      }}
-    >
-      <MinusIcon className="h-2.5 w-2.5" />
-    </Button>
+    <Tooltip>
+      <TooltipTrigger>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="mx-auto h-5 w-5 text-muted opacity-0 transition-opacity group-hover:opacity-100 group-focus-within:opacity-100 hover:bg-icon-button-hover"
+          aria-label={`Remove ${label.name}`}
+          onClick={async () => {
+            await draft.updateAndCommit((axis) => ({
+              ...axis,
+              labels: axis.labels.filter((item) => item.id !== label.id),
+            }));
+          }}
+        >
+          <MinusIcon className="h-2.5 w-2.5" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{`Remove ${label.name}`}</TooltipContent>
+    </Tooltip>
   </td>
 );
 

--- a/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { Axis, NamedInstance, NamedInstanceId } from "@shift/types";
-import { Input, cn } from "@shift/ui";
+import { Input, Tooltip, TooltipContent, TooltipTrigger, cn } from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
 import { SidebarActionButton, SidebarActionRow } from "@/components/sidebar/SidebarActionRow";
@@ -73,17 +73,24 @@ export const InstancesSettingsPanel = ({
               onClick={() => setSelectedInstanceId(instance.id)}
               contentClassName="h-8 text-sm font-normal"
               actions={
-                <SidebarActionButton
-                  label={`Delete ${instance.name}`}
-                  className="h-8 hover:bg-icon-button-hover"
-                  disabled={!canAuthor}
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    font.deleteNamedInstance(instance.id);
-                  }}
-                >
-                  <MinusIcon className="h-3 w-3" />
-                </SidebarActionButton>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <SidebarActionButton
+                      label={`Delete ${instance.name}`}
+                      className="h-8 hover:bg-icon-button-hover"
+                      aria-disabled={!canAuthor || undefined}
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (!canAuthor) return;
+
+                        font.deleteNamedInstance(instance.id);
+                      }}
+                    >
+                      <MinusIcon className="h-3 w-3" />
+                    </SidebarActionButton>
+                  </TooltipTrigger>
+                  <TooltipContent>{`Delete ${instance.name}`}</TooltipContent>
+                </Tooltip>
               }
             >
               <span className="truncate">{instance.name}</span>

--- a/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/InstancesSettingsPanel.tsx
@@ -53,9 +53,14 @@ export const InstancesSettingsPanel = ({
           {canAuthor ? (
             <CreateInstanceMenu onInstanceCreated={setPendingInstanceId} />
           ) : (
-            <SidebarActionButton label="Create instance" disabled>
-              <PlusIcon className="h-3 w-3" />
-            </SidebarActionButton>
+            <Tooltip>
+              <TooltipTrigger>
+                <SidebarActionButton label="Create instance" aria-disabled="true">
+                  <PlusIcon className="h-3 w-3" />
+                </SidebarActionButton>
+              </TooltipTrigger>
+              <TooltipContent>Create instance</TooltipContent>
+            </Tooltip>
           )}
         </div>
 

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SettingsDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SettingsDialog.tsx
@@ -6,6 +6,9 @@ import {
   DialogPopup,
   DialogPortal,
   DialogTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   X,
   cn,
 } from "@shift/ui";
@@ -59,16 +62,21 @@ export const SettingsDialog = ({
             aria-label="Settings details"
             className="relative min-h-0 min-w-0 overflow-hidden bg-canvas"
           >
-            <DialogClose
-              className={cn(
-                "absolute right-2 top-2 z-10 inline-flex h-7 w-7 cursor-pointer",
-                "items-center justify-center rounded text-primary/70 transition-colors",
-                "hover:bg-hover hover:text-primary",
-              )}
-              aria-label="Close settings"
-            >
-              <X className="h-4 w-4" />
-            </DialogClose>
+            <Tooltip>
+              <TooltipTrigger>
+                <DialogClose
+                  className={cn(
+                    "absolute right-2 top-2 z-10 inline-flex h-7 w-7 cursor-pointer",
+                    "items-center justify-center rounded text-primary/70 transition-colors",
+                    "hover:bg-hover hover:text-primary",
+                  )}
+                  aria-label="Close settings"
+                >
+                  <X className="h-4 w-4" />
+                </DialogClose>
+              </TooltipTrigger>
+              <TooltipContent>Close settings</TooltipContent>
+            </Tooltip>
 
             <SettingsCategoryPanel target={activeTarget} canAuthor={canAuthor} />
           </main>

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
@@ -78,11 +78,7 @@ export const SourcesSettingsPanel = ({ initialSourceId, canAuthor }: SourcesSett
                 <Tooltip>
                   <TooltipTrigger>
                     <SidebarActionButton
-                      label={
-                        source.id === font.defaultSource.id
-                          ? `Cannot delete ${source.name}: default source`
-                          : `Delete ${source.name}`
-                      }
+                      label={`Delete ${source.name}`}
                       className="h-8 hover:bg-icon-button-hover"
                       aria-disabled={
                         !canAuthor || sources.length === 1 || source.id === font.defaultSource.id
@@ -105,11 +101,7 @@ export const SourcesSettingsPanel = ({ initialSourceId, canAuthor }: SourcesSett
                       <MinusIcon className="h-3 w-3" />
                     </SidebarActionButton>
                   </TooltipTrigger>
-                  <TooltipContent>
-                    {source.id === font.defaultSource.id
-                      ? `Cannot delete ${source.name}: default source`
-                      : `Delete ${source.name}`}
-                  </TooltipContent>
+                  <TooltipContent>{`Delete ${source.name}`}</TooltipContent>
                 </Tooltip>
               }
             >

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
@@ -50,9 +50,14 @@ export const SourcesSettingsPanel = ({ initialSourceId, canAuthor }: SourcesSett
           {canAuthor ? (
             <CreateSourceMenu onSourceCreated={setPendingSourceId} />
           ) : (
-            <SidebarActionButton label="Create source" disabled>
-              <PlusIcon className="h-3 w-3" />
-            </SidebarActionButton>
+            <Tooltip>
+              <TooltipTrigger>
+                <SidebarActionButton label="Create source" aria-disabled="true">
+                  <PlusIcon className="h-3 w-3" />
+                </SidebarActionButton>
+              </TooltipTrigger>
+              <TooltipContent>Create source</TooltipContent>
+            </Tooltip>
           )}
         </div>
 

--- a/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/chrome/settings/SourcesSettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
 import type { Axis, MetricDefinition, Source, SourceId, SourceMetricValue } from "@shift/types";
-import { Input, cn } from "@shift/ui";
+import { Input, Tooltip, TooltipContent, TooltipTrigger, cn } from "@shift/ui";
 import MinusIcon from "@/assets/general/minus.svg";
 import PlusIcon from "@/assets/general/plus.svg";
 import { SidebarActionButton, SidebarActionRow } from "@/components/sidebar/SidebarActionRow";
@@ -70,23 +70,42 @@ export const SourcesSettingsPanel = ({ initialSourceId, canAuthor }: SourcesSett
               onClick={() => setSelectedSourceId(source.id)}
               contentClassName="h-8 text-sm font-normal"
               actions={
-                <SidebarActionButton
-                  label={
-                    source.id === font.defaultSource.id
+                <Tooltip>
+                  <TooltipTrigger>
+                    <SidebarActionButton
+                      label={
+                        source.id === font.defaultSource.id
+                          ? `Cannot delete ${source.name}: default source`
+                          : `Delete ${source.name}`
+                      }
+                      className="h-8 hover:bg-icon-button-hover"
+                      aria-disabled={
+                        !canAuthor || sources.length === 1 || source.id === font.defaultSource.id
+                          ? true
+                          : undefined
+                      }
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        if (
+                          !canAuthor ||
+                          sources.length === 1 ||
+                          source.id === font.defaultSource.id
+                        ) {
+                          return;
+                        }
+
+                        font.deleteSource(source.id);
+                      }}
+                    >
+                      <MinusIcon className="h-3 w-3" />
+                    </SidebarActionButton>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    {source.id === font.defaultSource.id
                       ? `Cannot delete ${source.name}: default source`
-                      : `Delete ${source.name}`
-                  }
-                  className="h-8 hover:bg-icon-button-hover"
-                  disabled={
-                    !canAuthor || sources.length === 1 || source.id === font.defaultSource.id
-                  }
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    font.deleteSource(source.id);
-                  }}
-                >
-                  <MinusIcon className="h-3 w-3" />
-                </SidebarActionButton>
+                      : `Delete ${source.name}`}
+                  </TooltipContent>
+                </Tooltip>
               }
             >
               <span className="truncate">{source.name}</span>

--- a/apps/desktop/src/renderer/src/components/editor/BooleanOps.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/BooleanOps.tsx
@@ -38,6 +38,7 @@ export const BooleanOps = () => {
     <SidebarSection title="Boolean">
       <div className="flex gap-2">
         <IconButton
+          ariaLabel="Union contours"
           icon={UnionIcon}
           disabled={!editable}
           onClick={async () => {
@@ -45,6 +46,7 @@ export const BooleanOps = () => {
           }}
         />
         <IconButton
+          ariaLabel="Intersect contours"
           icon={IntersectIcon}
           disabled={!editable}
           onClick={async () => {
@@ -52,6 +54,7 @@ export const BooleanOps = () => {
           }}
         />
         <IconButton
+          ariaLabel="Subtract contours"
           icon={SubtractIcon}
           disabled={!editable}
           onClick={async () => {

--- a/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import type { FC } from "react";
 
 import {
   Button,
@@ -6,13 +6,12 @@ import {
   ToolbarButton,
   Tooltip,
   TooltipContent,
-  TooltipProvider,
   TooltipTrigger,
   cn,
 } from "@shift/ui";
 import { useSignalState } from "@/lib/signals";
 import { useEditor } from "@/workspace/WorkspaceContext";
-import { SVG } from "@/types/common";
+import type { SVG } from "@/types/common";
 import type { ToolName } from "@/lib/tools/core";
 
 interface ToolbarIconProps {
@@ -34,16 +33,12 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({
   const isActive = activeTool === name;
 
   return (
-    <Tooltip delayDuration={1500}>
+    <Tooltip>
       <TooltipTrigger>
         <ToolbarButton
           render={
             <Button
-              className={cn(
-                "h-8 w-8 rounded-md",
-                !isActive && "hover:bg-icon-button-hover",
-                disabled && "cursor-default opacity-50",
-              )}
+              className={cn("h-8 w-8 rounded-md", !isActive && "hover:bg-icon-button-hover")}
               variant={isActive ? "primary" : "ghost"}
               icon={
                 <Icon
@@ -65,12 +60,8 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({
           }
         />
       </TooltipTrigger>
-      <TooltipContent
-        side="bottom"
-        sideOffset={5}
-        className="bg-surface px-2 py-1 text-primary border shadow-sm"
-      >
-        <p className="mb-1 font-sans text-[0.6rem] font-light">{tooltip}</p>
+      <TooltipContent side="bottom" sideOffset={5}>
+        {tooltip}
       </TooltipContent>
     </Tooltip>
   );
@@ -83,28 +74,26 @@ export const ToolsPane: FC = () => {
 
   return (
     <section className="flex flex-col items-center justify-center gap-2">
-      <TooltipProvider delayDuration={2000}>
-        <Toolbar
-          aria-label="Editor tools"
-          className="flex h-[40px] items-center gap-2 overflow-hidden rounded-lg border-b border-line bg-white px-1"
-        >
-          {Array.from(toolRegistry.entries())
-            .filter(([, item]) => !item.hidden)
-            .map(([name, { icon, tooltip, disabled }]) => (
-              <ToolbarIcon
-                key={name}
-                Icon={icon}
-                name={name}
-                tooltip={tooltip}
-                activeTool={activeTool}
-                disabled={disabled}
-                onClick={() => {
-                  editor.setActiveTool(name);
-                }}
-              />
-            ))}
-        </Toolbar>
-      </TooltipProvider>
+      <Toolbar
+        aria-label="Editor tools"
+        className="flex h-[40px] items-center gap-2 overflow-hidden rounded-lg border-b border-line bg-white px-1"
+      >
+        {Array.from(toolRegistry.entries())
+          .filter(([, item]) => !item.hidden)
+          .map(([name, { icon, tooltip, disabled }]) => (
+            <ToolbarIcon
+              key={name}
+              Icon={icon}
+              name={name}
+              tooltip={tooltip}
+              activeTool={activeTool}
+              disabled={disabled}
+              onClick={() => {
+                editor.setActiveTool(name);
+              }}
+            />
+          ))}
+      </Toolbar>
     </section>
   );
 };

--- a/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/ToolsPane.tsx
@@ -37,10 +37,13 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({
     <Tooltip delayDuration={1500}>
       <TooltipTrigger>
         <ToolbarButton
-          disabled={disabled}
           render={
             <Button
-              className={cn("h-8 w-8 rounded-md", !isActive && "hover:bg-icon-button-hover")}
+              className={cn(
+                "h-8 w-8 rounded-md",
+                !isActive && "hover:bg-icon-button-hover",
+                disabled && "cursor-default opacity-50",
+              )}
               variant={isActive ? "primary" : "ghost"}
               icon={
                 <Icon
@@ -49,9 +52,13 @@ export const ToolbarIcon: FC<ToolbarIconProps> = ({
                 />
               }
               aria-label={tooltip}
-              disabled={disabled}
+              aria-disabled={disabled || undefined}
               isActive={isActive}
-              onClick={onClick}
+              onClick={() => {
+                if (disabled) return;
+
+                if (onClick) onClick();
+              }}
               data-read-only-mutation={onClick ? undefined : true}
               size="icon"
             />

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/AnchorSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/AnchorSection.tsx
@@ -58,12 +58,14 @@ export const AnchorSection = () => {
       <div className="flex gap-2">
         <EditableSidebarInput
           ref={xRef}
+          ariaLabel="Anchor X position"
           label="X"
           disabled={!editable}
           onValueChange={(value) => handlePositionChange("x", value)}
         />
         <EditableSidebarInput
           ref={yRef}
+          ariaLabel="Anchor Y position"
           label="Y"
           disabled={!editable}
           onValueChange={(value) => handlePositionChange("y", value)}

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/EditableSidebarInput.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/EditableSidebarInput.tsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
-import { cn, Input } from "@shift/ui";
+import { cn, Input, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import { NUDGES_VALUES, type NudgeMagnitude } from "@/types/nudge";
 import { useFocusZone } from "@/context/FocusZoneContext";
 
@@ -8,7 +8,7 @@ export interface EditableSidebarInputHandle {
 }
 
 interface EditableSidebarInputProps {
-  ariaLabel?: string;
+  ariaLabel: string;
   label?: string | React.ReactNode;
   labelPosition?: "left" | "right";
   className?: string;
@@ -132,27 +132,32 @@ export const EditableSidebarInput = forwardRef<
     }, []);
 
     return (
-      <Input
-        ref={inputRef}
-        aria-label={ariaLabel}
-        label={label}
-        labelPosition={labelPosition}
-        value={isEditing ? editValue : displayValue === null ? "" : `${displayValue}${suffix}`}
-        icon={icon}
-        iconPosition={iconPosition}
-        readOnly={!isEditing}
-        className={cn(
-          "w-full bg-[#f3f3f3]",
-          label && labelPosition !== "right" && "pl-6",
-          label && labelPosition === "right" && "pr-6",
-          className,
-        )}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-        onChange={handleChange}
-        disabled={disabled}
-      />
+      <Tooltip>
+        <TooltipTrigger>
+          <Input
+            ref={inputRef}
+            aria-label={ariaLabel}
+            label={label}
+            labelPosition={labelPosition}
+            value={isEditing ? editValue : displayValue === null ? "" : `${displayValue}${suffix}`}
+            icon={icon}
+            iconPosition={iconPosition}
+            readOnly={!isEditing}
+            className={cn(
+              "w-full bg-[#f3f3f3]",
+              label && labelPosition !== "right" && "pl-6",
+              label && labelPosition === "right" && "pr-6",
+              className,
+            )}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onKeyDown={handleKeyDown}
+            onChange={handleChange}
+            disabled={disabled}
+          />
+        </TooltipTrigger>
+        <TooltipContent>{ariaLabel}</TooltipContent>
+      </Tooltip>
     );
   },
 );

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, TooltipContent, TooltipTrigger, cn } from "@shift/ui";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 
 type IconButtonProps = {
   ariaLabel: string;
@@ -13,10 +13,7 @@ export const IconButton = ({ ariaLabel, icon: Icon, onClick, disabled }: IconBut
       <Button
         aria-label={ariaLabel}
         aria-disabled={disabled || undefined}
-        className={cn(
-          "h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover",
-          disabled && "cursor-default opacity-50",
-        )}
+        className="h-6 w-6 bg-icon-button p-1 text-sidebar-icon hover:bg-icon-button-hover"
         variant="ghost"
         onClick={() => {
           if (disabled) return;

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
@@ -1,20 +1,25 @@
-import { Button } from "@shift/ui";
+import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 
 type IconButtonProps = {
-  ariaLabel?: string;
+  ariaLabel: string;
   icon: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   onClick: () => void;
   disabled?: boolean;
 };
 
 export const IconButton = ({ ariaLabel, icon: Icon, onClick, disabled }: IconButtonProps) => (
-  <Button
-    aria-label={ariaLabel}
-    className="h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover"
-    variant="ghost"
-    onClick={onClick}
-    disabled={disabled}
-  >
-    <Icon className="w-full h-full" />
-  </Button>
+  <Tooltip>
+    <TooltipTrigger>
+      <Button
+        aria-label={ariaLabel}
+        className="h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover"
+        variant="ghost"
+        onClick={onClick}
+        disabled={disabled}
+      >
+        <Icon className="w-full h-full" />
+      </Button>
+    </TooltipTrigger>
+    <TooltipContent>{ariaLabel}</TooltipContent>
+  </Tooltip>
 );

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/IconButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
+import { Button, Tooltip, TooltipContent, TooltipTrigger, cn } from "@shift/ui";
 
 type IconButtonProps = {
   ariaLabel: string;
@@ -12,10 +12,17 @@ export const IconButton = ({ ariaLabel, icon: Icon, onClick, disabled }: IconBut
     <TooltipTrigger>
       <Button
         aria-label={ariaLabel}
-        className="h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover"
+        aria-disabled={disabled || undefined}
+        className={cn(
+          "h-6 w-6 p-1 text-sidebar-icon bg-icon-button hover:bg-icon-button-hover",
+          disabled && "cursor-default opacity-50",
+        )}
         variant="ghost"
-        onClick={onClick}
-        disabled={disabled}
+        onClick={() => {
+          if (disabled) return;
+
+          onClick();
+        }}
       >
         <Icon className="w-full h-full" />
       </Button>

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/ScaleSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/ScaleSection.tsx
@@ -70,12 +70,14 @@ export const ScaleSection = () => {
         <div className="flex gap-2">
           <EditableSidebarInput
             ref={widthRef}
+            ariaLabel="Width"
             label={<span className="text-xs text-secondary">W</span>}
             disabled={!editable}
             onValueChange={(v) => handleSizeChange("width", v)}
           />
           <EditableSidebarInput
             ref={heightRef}
+            ariaLabel="Height"
             label="H"
             disabled={!editable}
             onValueChange={(v) => handleSizeChange("height", v)}

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
@@ -1,3 +1,5 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
+
 export type AnchorPosition = "tl" | "tm" | "tr" | "lm" | "m" | "rm" | "bl" | "bm" | "br";
 
 export interface TransformGridProps {
@@ -43,17 +45,23 @@ export const TransformGrid = ({
     >
       <rect x="4" y="4" width="54" height="44" stroke="#C2C2C2" strokeWidth="2" />
       {anchorPositions.map(({ id, label, cx, cy }) => (
-        <circle
-          key={id}
-          role="button"
-          aria-label={label}
-          cx={cx}
-          cy={cy}
-          r="4"
-          fill={activeAnchor === id ? ACTIVE_COLOR : INACTIVE_COLOR}
-          style={{ cursor: onChange ? "pointer" : "default" }}
-          onClick={() => onChange?.(id)}
-        />
+        <Tooltip key={id}>
+          <TooltipTrigger>
+            <circle
+              role="button"
+              aria-label={label}
+              cx={cx}
+              cy={cy}
+              r="4"
+              fill={activeAnchor === id ? ACTIVE_COLOR : INACTIVE_COLOR}
+              style={{ cursor: onChange ? "pointer" : "default" }}
+              onClick={() => {
+                if (onChange) onChange(id);
+              }}
+            />
+          </TooltipTrigger>
+          <TooltipContent>{label}</TooltipContent>
+        </Tooltip>
       ))}
     </svg>
   );

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformGrid.tsx
@@ -1,4 +1,4 @@
-import { Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
+import { cn, Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 
 export type AnchorPosition = "tl" | "tm" | "tr" | "lm" | "m" | "rm" | "bl" | "bm" | "br";
 
@@ -9,24 +9,21 @@ export interface TransformGridProps {
   onChange?: (anchor: AnchorPosition) => void;
 }
 
-const INACTIVE_COLOR = "#C2C2C2";
-const ACTIVE_COLOR = "#0C92F4";
-
 const anchorPositions: {
   id: AnchorPosition;
   label: string;
   cx: number;
   cy: number;
 }[] = [
-  { id: "tl", label: "Top-left scale anchor", cx: 4, cy: 4 },
-  { id: "tm", label: "Top scale anchor", cx: 31, cy: 4 },
-  { id: "tr", label: "Top-right scale anchor", cx: 58, cy: 4 },
-  { id: "lm", label: "Left scale anchor", cx: 4, cy: 27 },
-  { id: "m", label: "Center scale anchor", cx: 32, cy: 27 },
-  { id: "rm", label: "Right scale anchor", cx: 58, cy: 27 },
-  { id: "bl", label: "Bottom-left scale anchor", cx: 4, cy: 48 },
-  { id: "bm", label: "Bottom scale anchor", cx: 31, cy: 48 },
-  { id: "br", label: "Bottom-right scale anchor", cx: 58, cy: 48 },
+  { id: "tl", label: "Anchor top left", cx: 4, cy: 4 },
+  { id: "tm", label: "Anchor top", cx: 31, cy: 4 },
+  { id: "tr", label: "Anchor top right", cx: 58, cy: 4 },
+  { id: "lm", label: "Anchor left", cx: 4, cy: 27 },
+  { id: "m", label: "Anchor center", cx: 32, cy: 27 },
+  { id: "rm", label: "Anchor right", cx: 58, cy: 27 },
+  { id: "bl", label: "Anchor bottom left", cx: 4, cy: 48 },
+  { id: "bm", label: "Anchor bottom", cx: 31, cy: 48 },
+  { id: "br", label: "Anchor bottom right", cx: 58, cy: 48 },
 ];
 
 export const TransformGrid = ({
@@ -53,7 +50,11 @@ export const TransformGrid = ({
               cx={cx}
               cy={cy}
               r="4"
-              fill={activeAnchor === id ? ACTIVE_COLOR : INACTIVE_COLOR}
+              className={cn(
+                "transition-colors",
+                activeAnchor === id ? "fill-accent" : "fill-[#c2c2c2]",
+                onChange && activeAnchor !== id && "hover:fill-accent/70",
+              )}
               style={{ cursor: onChange ? "pointer" : "default" }}
               onClick={() => {
                 if (onChange) onChange(id);

--- a/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformSection.tsx
+++ b/apps/desktop/src/renderer/src/components/editor/sidebar-right/TransformSection.tsx
@@ -34,29 +34,39 @@ const AlignButtonsRow = React.memo(function AlignButtonsRow({
     <div className="flex gap-4">
       <div className="flex gap-1">
         <IconButton
+          ariaLabel="Align left"
           icon={AlignLeftIcon}
           onClick={() => onAlign("left")}
           disabled={!canDistribute}
         />
         <IconButton
+          ariaLabel="Align horizontal centers"
           icon={AlignCenterHIcon}
           onClick={() => onAlign("center-h")}
           disabled={!canDistribute}
         />
         <IconButton
+          ariaLabel="Align right"
           icon={AlignRightIcon}
           onClick={() => onAlign("right")}
           disabled={!canDistribute}
         />
       </div>
       <div className="flex gap-1">
-        <IconButton icon={AlignTopIcon} onClick={() => onAlign("top")} disabled={!canDistribute} />
         <IconButton
+          ariaLabel="Align top"
+          icon={AlignTopIcon}
+          onClick={() => onAlign("top")}
+          disabled={!canDistribute}
+        />
+        <IconButton
+          ariaLabel="Align vertical centers"
           icon={AlignCenterVIcon}
           onClick={() => onAlign("center-v")}
           disabled={!canDistribute}
         />
         <IconButton
+          ariaLabel="Align bottom"
           icon={AlignBottomIcon}
           onClick={() => onAlign("bottom")}
           disabled={!canDistribute}
@@ -76,11 +86,13 @@ const DistributeButtonsRow = React.memo(function DistributeButtonsRow({
   return (
     <div className="flex gap-1">
       <IconButton
+        ariaLabel="Distribute horizontally"
         icon={DistributeHorizontalIcon}
         onClick={() => onDistribute("horizontal")}
         disabled={!canDistribute}
       />
       <IconButton
+        ariaLabel="Distribute vertically"
         icon={DistributeVerticalIcon}
         onClick={() => onDistribute("vertical")}
         disabled={!canDistribute}

--- a/apps/desktop/src/renderer/src/components/home/glyph-catalog/GlyphCatalogView.tsx
+++ b/apps/desktop/src/renderer/src/components/home/glyph-catalog/GlyphCatalogView.tsx
@@ -6,6 +6,9 @@ import {
   CollapsibleTrigger,
   Input,
   Search,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 
 import AllIcon from "@/assets/sidebar-left/all.svg";
@@ -49,16 +52,20 @@ export const GlyphCatalogView = () => {
       <div className="flex-1 overflow-y-auto scrollbar-hidden">
         <div className="flex items-center justify-between font-sans mb-2">
           <span className="text-ui font-medium text-primary">Glyphs</span>
-          <Button
-            variant="ghost"
-            size="sm"
-            aria-label="Create glyph"
-            title="Create glyph"
-            onClick={canAuthor ? createQuickGlyph : undefined}
-            data-read-only-mutation={canAuthor ? undefined : true}
-          >
-            <PlusIcon className="w-3 h-3 text-muted" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger>
+              <Button
+                variant="ghost"
+                size="sm"
+                aria-label="Create glyph"
+                onClick={canAuthor ? createQuickGlyph : undefined}
+                data-read-only-mutation={canAuthor ? undefined : true}
+              >
+                <PlusIcon className="w-3 h-3 text-muted" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Create glyph</TooltipContent>
+          </Tooltip>
         </div>
 
         <div className="w-full">

--- a/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
+++ b/apps/desktop/src/renderer/src/components/sidebar/SidebarActionRow.tsx
@@ -1,5 +1,5 @@
 import { Button, cn, type ButtonProps } from "@shift/ui";
-import type { ReactNode } from "react";
+import { forwardRef, type ReactNode } from "react";
 
 interface SidebarActionRowProps {
   children: ReactNode;
@@ -73,20 +73,19 @@ interface SidebarActionButtonProps extends Omit<ButtonProps, "children" | "size"
   children: ReactNode;
 }
 
-export const SidebarActionButton = ({
-  label,
-  children,
-  className,
-  ...props
-}: SidebarActionButtonProps) => (
-  <Button
-    variant="ghost"
-    size="icon-sm"
-    aria-label={label}
-    title={label}
-    className={cn("h-6 w-6 p-0.5 text-muted hover:text-primary", className)}
-    {...props}
-  >
-    {children}
-  </Button>
+export const SidebarActionButton = forwardRef<HTMLButtonElement, SidebarActionButtonProps>(
+  ({ label, children, className, ...props }, ref) => (
+    <Button
+      ref={ref}
+      variant="ghost"
+      size="icon-sm"
+      aria-label={label}
+      className={cn("h-6 w-6 p-0.5 text-muted hover:text-primary", className)}
+      {...props}
+    >
+      {children}
+    </Button>
+  ),
 );
+
+SidebarActionButton.displayName = "SidebarActionButton";

--- a/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesPanel.tsx
@@ -9,6 +9,9 @@ import {
   MenuSeparator,
   MenuTrigger,
   Slider,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 import { EditableSidebarInput } from "@/components/editor/sidebar-right/EditableSidebarInput";
 import { useSettingsNavigation } from "@/context/SettingsNavigationContext";
@@ -115,18 +118,23 @@ interface AxisActionsMenuProps {
 
 const AxisActionsMenu = ({ axis, onEdit, onReset, onDelete }: AxisActionsMenuProps) => (
   <Menu modal={false}>
-    <MenuTrigger
-      render={
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="h-6 w-6 p-0.5"
-          aria-label={`Actions for ${axis.name}`}
-        />
-      }
-    >
-      <VerticalElipsis className="h-5 w-5" />
-    </MenuTrigger>
+    <Tooltip>
+      <TooltipTrigger>
+        <MenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="h-6 w-6 p-0.5"
+              aria-label={`Actions for ${axis.name}`}
+            />
+          }
+        >
+          <VerticalElipsis className="h-5 w-5" />
+        </MenuTrigger>
+      </TooltipTrigger>
+      <TooltipContent>{`Actions for ${axis.name}`}</TooltipContent>
+    </Tooltip>
     <MenuPortal>
       <MenuPositioner sideOffset={4} align="end">
         <MenuPopup>

--- a/apps/desktop/src/renderer/src/components/variation/AxesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/AxesSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import { CollapsibleSection, SidebarActionButton } from "@/components/sidebar";
 import { AxesPanel } from "./AxesPanel";
 import { CreateAxisMenu } from "./CreateAxisMenu";
@@ -24,9 +25,14 @@ export const AxesSection = ({ defaultOpen = false }: AxesSectionProps) => {
         canAuthor ? (
           <CreateAxisMenu onOpenChange={setAxisMenuOpen} />
         ) : (
-          <SidebarActionButton label="Create axis" data-read-only-mutation>
-            <PlusIcon className="h-3 w-3" />
-          </SidebarActionButton>
+          <Tooltip>
+            <TooltipTrigger>
+              <SidebarActionButton label="Create axis" data-read-only-mutation>
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            </TooltipTrigger>
+            <TooltipContent>Create axis</TooltipContent>
+          </Tooltip>
         )
       }
     >

--- a/apps/desktop/src/renderer/src/components/variation/CreateAxisMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateAxisMenu.tsx
@@ -7,6 +7,9 @@ import {
   MenuPositioner,
   MenuSeparator,
   MenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 import PlusIcon from "@/assets/general/plus.svg";
 import { SidebarActionButton } from "@/components/sidebar";
@@ -34,24 +37,34 @@ export const CreateAxisMenu = ({ onAxisCreated, onOpenChange }: CreateAxisMenuPr
 
   if (availablePresets.length === 0) {
     return (
-      <SidebarActionButton
-        label="Create custom axis"
-        onClick={() => createAxis(nextCustomAxisDefinition(axes))}
-      >
-        <PlusIcon className="h-3 w-3" />
-      </SidebarActionButton>
+      <Tooltip>
+        <TooltipTrigger>
+          <SidebarActionButton
+            label="Create custom axis"
+            onClick={() => createAxis(nextCustomAxisDefinition(axes))}
+          >
+            <PlusIcon className="h-3 w-3" />
+          </SidebarActionButton>
+        </TooltipTrigger>
+        <TooltipContent>Create custom axis</TooltipContent>
+      </Tooltip>
     );
   }
 
   return (
     <Menu modal={false} onOpenChange={onOpenChange}>
-      <MenuTrigger
-        render={
-          <SidebarActionButton label="Create axis">
-            <PlusIcon className="h-3 w-3" />
-          </SidebarActionButton>
-        }
-      />
+      <Tooltip>
+        <TooltipTrigger>
+          <MenuTrigger
+            render={
+              <SidebarActionButton label="Create axis">
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            }
+          />
+        </TooltipTrigger>
+        <TooltipContent>Create axis</TooltipContent>
+      </Tooltip>
       <MenuPortal>
         <MenuPositioner sideOffset={4} align="start">
           <MenuPopup className="w-50 p-2">

--- a/apps/desktop/src/renderer/src/components/variation/CreateInstanceMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateInstanceMenu.tsx
@@ -120,11 +120,11 @@ export const CreateInstanceMenu = ({
     return (
       <Tooltip>
         <TooltipTrigger>
-          <SidebarActionButton label="Add an axis before creating instances" aria-disabled="true">
+          <SidebarActionButton label="Create instance" aria-disabled="true">
             <PlusIcon className="h-3 w-3" />
           </SidebarActionButton>
         </TooltipTrigger>
-        <TooltipContent>Add an axis before creating instances</TooltipContent>
+        <TooltipContent>Create instance</TooltipContent>
       </Tooltip>
     );
   }

--- a/apps/desktop/src/renderer/src/components/variation/CreateInstanceMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateInstanceMenu.tsx
@@ -12,6 +12,9 @@ import {
   PopoverPositioner,
   PopoverTitle,
   PopoverTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   X,
   cn,
 } from "@shift/ui";
@@ -113,18 +116,33 @@ export const CreateInstanceMenu = ({
     handleOpenChange(false);
   };
 
-  return (
-    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
-      <PopoverTrigger
-        render={
-          <SidebarActionButton
-            label={axes.length > 0 ? "Create instance" : "Add an axis before creating instances"}
-            disabled={axes.length === 0}
-          >
+  if (axes.length === 0) {
+    return (
+      <Tooltip>
+        <TooltipTrigger>
+          <SidebarActionButton label="Add an axis before creating instances" aria-disabled="true">
             <PlusIcon className="h-3 w-3" />
           </SidebarActionButton>
-        }
-      />
+        </TooltipTrigger>
+        <TooltipContent>Add an axis before creating instances</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
+      <Tooltip>
+        <TooltipTrigger>
+          <PopoverTrigger
+            render={
+              <SidebarActionButton label="Create instance">
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            }
+          />
+        </TooltipTrigger>
+        <TooltipContent>Create instance</TooltipContent>
+      </Tooltip>
       <PopoverPortal>
         <PopoverPositioner sideOffset={4} align="start">
           <PopoverPopup className="w-50 p-0" initialFocus={nameInputRef}>
@@ -132,15 +150,20 @@ export const CreateInstanceMenu = ({
               <PopoverTitle className="text-ui font-medium text-primary">
                 Create Instance
               </PopoverTitle>
-              <PopoverClose
-                className={cn(
-                  "inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                  "text-primary/70 transition-colors hover:bg-hover hover:text-primary",
-                )}
-                aria-label="Close"
-              >
-                <X className="h-4 w-4" />
-              </PopoverClose>
+              <Tooltip>
+                <TooltipTrigger>
+                  <PopoverClose
+                    className={cn(
+                      "inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                      "text-primary/70 transition-colors hover:bg-hover hover:text-primary",
+                    )}
+                    aria-label="Close"
+                  >
+                    <X className="h-4 w-4" />
+                  </PopoverClose>
+                </TooltipTrigger>
+                <TooltipContent>Close</TooltipContent>
+              </Tooltip>
             </div>
 
             <form onSubmit={handleSubmit}>

--- a/apps/desktop/src/renderer/src/components/variation/CreateSourceMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateSourceMenu.tsx
@@ -136,7 +136,7 @@ export const CreateSourceMenu = ({ onSourceCreated, onOpenChange }: CreateSource
             <PlusIcon className="h-3 w-3" />
           </SidebarActionButton>
         </TooltipTrigger>
-        <TooltipContent>Create an axis before adding another source</TooltipContent>
+        <TooltipContent>Create source</TooltipContent>
       </Tooltip>
     );
   }

--- a/apps/desktop/src/renderer/src/components/variation/CreateSourceMenu.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/CreateSourceMenu.tsx
@@ -11,6 +11,9 @@ import {
   PopoverPositioner,
   PopoverTitle,
   PopoverTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   X,
   cn,
 } from "@shift/ui";
@@ -125,15 +128,33 @@ export const CreateSourceMenu = ({ onSourceCreated, onOpenChange }: CreateSource
     handleOpenChange(false);
   };
 
-  return (
-    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
-      <PopoverTrigger
-        render={
-          <SidebarActionButton label="Create source">
+  if (axes.length === 0) {
+    return (
+      <Tooltip>
+        <TooltipTrigger>
+          <SidebarActionButton label="Create source" aria-disabled="true">
             <PlusIcon className="h-3 w-3" />
           </SidebarActionButton>
-        }
-      />
+        </TooltipTrigger>
+        <TooltipContent>Create an axis before adding another source</TooltipContent>
+      </Tooltip>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
+      <Tooltip>
+        <TooltipTrigger>
+          <PopoverTrigger
+            render={
+              <SidebarActionButton label="Create source">
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            }
+          />
+        </TooltipTrigger>
+        <TooltipContent>Create source</TooltipContent>
+      </Tooltip>
       <PopoverPortal>
         <PopoverPositioner sideOffset={4} align="start">
           <PopoverPopup className="w-50 p-0" initialFocus={nameInputRef}>
@@ -141,15 +162,20 @@ export const CreateSourceMenu = ({ onSourceCreated, onOpenChange }: CreateSource
               <PopoverTitle className="text-ui font-medium text-primary">
                 Create Source
               </PopoverTitle>
-              <PopoverClose
-                className={cn(
-                  "inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded",
-                  "text-primary/70 transition-colors hover:bg-hover hover:text-primary",
-                )}
-                aria-label="Close"
-              >
-                <X className="h-4 w-4" />
-              </PopoverClose>
+              <Tooltip>
+                <TooltipTrigger>
+                  <PopoverClose
+                    className={cn(
+                      "inline-flex h-6 w-6 cursor-pointer items-center justify-center rounded",
+                      "text-primary/70 transition-colors hover:bg-hover hover:text-primary",
+                    )}
+                    aria-label="Close"
+                  >
+                    <X className="h-4 w-4" />
+                  </PopoverClose>
+                </TooltipTrigger>
+                <TooltipContent>Close</TooltipContent>
+              </Tooltip>
             </div>
 
             <form onSubmit={handleSubmit}>

--- a/apps/desktop/src/renderer/src/components/variation/Instances.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Instances.tsx
@@ -8,6 +8,9 @@ import {
   MenuPositioner,
   MenuSeparator,
   MenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 import VerticalEllipsis from "@/assets/general/vertical-ellipsis.svg";
 import { SidebarActionRow } from "@/components/sidebar";
@@ -67,18 +70,23 @@ interface InstanceActionsMenuProps {
 
 const InstanceActionsMenu = ({ instanceName, onEdit, onDelete }: InstanceActionsMenuProps) => (
   <Menu modal={false}>
-    <MenuTrigger
-      render={
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="h-6 w-6 p-0.5"
-          aria-label={`Actions for ${instanceName}`}
-        />
-      }
-    >
-      <VerticalEllipsis className="h-5 w-5" />
-    </MenuTrigger>
+    <Tooltip>
+      <TooltipTrigger>
+        <MenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="h-6 w-6 p-0.5"
+              aria-label={`Actions for ${instanceName}`}
+            />
+          }
+        >
+          <VerticalEllipsis className="h-5 w-5" />
+        </MenuTrigger>
+      </TooltipTrigger>
+      <TooltipContent>{`Actions for ${instanceName}`}</TooltipContent>
+    </Tooltip>
     <MenuPortal>
       <MenuPositioner sideOffset={4} align="end">
         <MenuPopup>

--- a/apps/desktop/src/renderer/src/components/variation/Instances.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Instances.tsx
@@ -85,7 +85,7 @@ const InstanceActionsMenu = ({ instanceName, onEdit, onDelete }: InstanceActions
           <VerticalEllipsis className="h-5 w-5" />
         </MenuTrigger>
       </TooltipTrigger>
-      <TooltipContent>{`Actions for ${instanceName}`}</TooltipContent>
+      <TooltipContent>{"Edit instance"}</TooltipContent>
     </Tooltip>
     <MenuPortal>
       <MenuPositioner sideOffset={4} align="end">

--- a/apps/desktop/src/renderer/src/components/variation/InstancesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/InstancesSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import { CollapsibleSection, SidebarActionButton } from "@/components/sidebar";
 import { CreateInstanceMenu } from "./CreateInstanceMenu";
 import { Instances } from "./Instances";
@@ -24,9 +25,14 @@ export const InstancesSection = ({ defaultOpen = false }: InstancesSectionProps)
         canAuthor ? (
           <CreateInstanceMenu onOpenChange={setInstanceMenuOpen} />
         ) : (
-          <SidebarActionButton label="Create instance" data-read-only-mutation>
-            <PlusIcon className="h-3 w-3" />
-          </SidebarActionButton>
+          <Tooltip>
+            <TooltipTrigger>
+              <SidebarActionButton label="Create instance" data-read-only-mutation>
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            </TooltipTrigger>
+            <TooltipContent>Create instance</TooltipContent>
+          </Tooltip>
         )
       }
     >

--- a/apps/desktop/src/renderer/src/components/variation/Sources.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Sources.tsx
@@ -7,6 +7,9 @@ import {
   MenuPositioner,
   MenuSeparator,
   MenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@shift/ui";
 import type { SourceId } from "@shift/types";
 import { useSources } from "@/hooks/useSources";
@@ -84,18 +87,23 @@ const SourceActionsMenu = ({
   onDelete: () => void;
 }) => (
   <Menu modal={false}>
-    <MenuTrigger
-      render={
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          className="h-6 w-6 p-0.5"
-          aria-label={`Actions for ${sourceName}`}
-        />
-      }
-    >
-      <VerticalElipsis className="h-5 w-5" />
-    </MenuTrigger>
+    <Tooltip>
+      <TooltipTrigger>
+        <MenuTrigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="h-6 w-6 p-0.5"
+              aria-label={`Actions for ${sourceName}`}
+            />
+          }
+        >
+          <VerticalElipsis className="h-5 w-5" />
+        </MenuTrigger>
+      </TooltipTrigger>
+      <TooltipContent>{`Actions for ${sourceName}`}</TooltipContent>
+    </Tooltip>
     <MenuPortal>
       <MenuPositioner sideOffset={4} align="end">
         <MenuPopup>

--- a/apps/desktop/src/renderer/src/components/variation/Sources.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/Sources.tsx
@@ -102,16 +102,20 @@ const SourceActionsMenu = ({
           <VerticalElipsis className="h-5 w-5" />
         </MenuTrigger>
       </TooltipTrigger>
-      <TooltipContent>{`Actions for ${sourceName}`}</TooltipContent>
+      <TooltipContent>{`Edit source`}</TooltipContent>
     </Tooltip>
     <MenuPortal>
-      <MenuPositioner sideOffset={4} align="end">
+      <MenuPositioner sideOffset={4} align="start">
         <MenuPopup>
           <MenuItem onClick={onEdit}>Edit</MenuItem>
-          <MenuSeparator />
-          <MenuItem variant="danger" disabled={!canDelete} onClick={onDelete}>
-            {isDefaultSource ? "Default source cannot be deleted" : "Delete source"}
-          </MenuItem>
+          {!isDefaultSource && (
+            <>
+              <MenuSeparator />
+              <MenuItem variant="danger" disabled={!canDelete} onClick={onDelete}>
+                "Delete source"
+              </MenuItem>
+            </>
+          )}
         </MenuPopup>
       </MenuPositioner>
     </MenuPortal>

--- a/apps/desktop/src/renderer/src/components/variation/SourcesSection.tsx
+++ b/apps/desktop/src/renderer/src/components/variation/SourcesSection.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@shift/ui";
 import { CollapsibleSection, SidebarActionButton } from "@/components/sidebar";
 import { CreateSourceMenu } from "./CreateSourceMenu";
 import { Sources } from "./Sources";
@@ -24,9 +25,14 @@ export const SourcesSection = ({ defaultOpen = false }: SourcesSectionProps) => 
         canAuthor ? (
           <CreateSourceMenu onOpenChange={setSourceMenuOpen} />
         ) : (
-          <SidebarActionButton label="Create source" data-read-only-mutation>
-            <PlusIcon className="h-3 w-3" />
-          </SidebarActionButton>
+          <Tooltip>
+            <TooltipTrigger>
+              <SidebarActionButton label="Create source" data-read-only-mutation>
+                <PlusIcon className="h-3 w-3" />
+              </SidebarActionButton>
+            </TooltipTrigger>
+            <TooltipContent>Create source</TooltipContent>
+          </Tooltip>
         )
       }
     >

--- a/packages/ui/src/components/button/Button.tsx
+++ b/packages/ui/src/components/button/Button.tsx
@@ -35,6 +35,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           "inline-flex cursor-pointer items-center justify-center gap-2 rounded transition-colors duration-200",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
           "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+          "aria-disabled:cursor-default aria-disabled:opacity-50",
           variantStyles[variant],
           sizeStyles[size],
           className,

--- a/packages/ui/src/components/tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/tooltip/Tooltip.tsx
@@ -28,13 +28,11 @@ function Tooltip({ children, delayDuration }: TooltipProps) {
 }
 
 interface TooltipTriggerProps {
-  children: React.ReactNode;
+  children: React.ReactElement<Record<string, unknown>>;
 }
 
 function TooltipTrigger({ children }: TooltipTriggerProps) {
-  return (
-    <BaseTooltip.Trigger render={<span className="inline-flex" />}>{children}</BaseTooltip.Trigger>
-  );
+  return <BaseTooltip.Trigger render={children} />;
 }
 
 interface TooltipContentProps {
@@ -54,6 +52,7 @@ function TooltipContent({
     <BaseTooltip.Portal>
       <BaseTooltip.Positioner side={side} sideOffset={sideOffset}>
         <BaseTooltip.Popup
+          role="tooltip"
           className={cn(
             "z-50 rounded-md bg-surface px-3 py-1.5 text-xs text-primary border shadow-sm",
             "animate-in fade-in-0 zoom-in-95",

--- a/packages/ui/src/components/tooltip/Tooltip.tsx
+++ b/packages/ui/src/components/tooltip/Tooltip.tsx
@@ -46,7 +46,7 @@ function TooltipContent({
   children,
   className,
   side = "top",
-  sideOffset = 0,
+  sideOffset = 5,
 }: TooltipContentProps) {
   return (
     <BaseTooltip.Portal>
@@ -54,11 +54,22 @@ function TooltipContent({
         <BaseTooltip.Popup
           role="tooltip"
           className={cn(
-            "z-50 rounded-md bg-surface px-3 py-1.5 text-xs text-primary border shadow-sm",
+            "relative z-50 rounded-md bg-surface-inverse px-3 py-1.5 text-ui text-on-surface-inverse shadow-lg",
             "animate-in fade-in-0 zoom-in-95",
             className,
           )}
         >
+          <BaseTooltip.Arrow
+            className={cn(
+              "relative block h-1.5 w-3 overflow-clip",
+              "data-[side=bottom]:-top-1.5 data-[side=left]:-right-[9px] data-[side=left]:rotate-90",
+              "data-[side=right]:-left-[9px] data-[side=right]:-rotate-90",
+              "data-[side=top]:-bottom-1.5 data-[side=top]:rotate-180",
+              "before:absolute before:bottom-0 before:left-1/2 before:size-[calc(6px*sqrt(2))]",
+              "before:bg-surface-inverse before:content-['']",
+              "before:[transform:translate(-50%,50%)_rotate(45deg)]",
+            )}
+          />
           {children}
         </BaseTooltip.Popup>
       </BaseTooltip.Positioner>


### PR DESCRIPTION
## Summary

- add accessible tooltips to icon-only controls across navigation, editor toolbars and sidebars, variation panels, Settings, dialogs, popovers, and zoom controls
- keep unavailable actions hoverable and focusable with guarded `aria-disabled` behavior, including contextual prerequisite explanations
- preserve Base UI trigger/ref composition and add focused E2E coverage for enabled, unavailable, and SVG anchor controls

## Issue

Closes #342

## Testing

Passed:

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint:check`
- `git diff --check`
- `pnpm test:e2e:visual e2e/home.spec.ts --grep "explains why source creation is unavailable without axes"`
- `pnpm test:e2e:visual e2e/editor.spec.ts --grep "explains icon-only editor actions on hover"`
- `pnpm test:e2e:visual e2e/variable-font-authoring.spec.ts --grep "edits and removes variable records through Settings"`

Not completed:

- `pnpm test:e2e:visual e2e/home.spec.ts` — three rendering tests failed because GLX/GPU rendering was unavailable; three non-rendering tests passed
- `pnpm test:e2e:visual e2e/font-preview.spec.ts --grep "shows preview font settings with disabled authoring controls"` — the visual project excludes this GPU-only spec, so Playwright reported no matching tests
- macOS visual verification and review screenshots were not available; focused E2E coverage verifies rendered tooltip text, hover/focus behavior, and unavailable-state semantics
