### PR TITLE
feat(geo): add tangent-preserving cubic fitting

### DIFF
--- a/packages/geo/src/Curve.ts
+++ b/packages/geo/src/Curve.ts
@@ -27,6 +27,7 @@
 import type { Point2D } from "./types";
 import type { Bounds } from "./Bounds";
 import { Vec2 } from "./Vec2";
+import { fitCubic } from "./fitCubic";
 
 // ============================================
 // Types
@@ -92,6 +93,8 @@ const NEWTON_MAX_ITERATIONS = 8;
 // ============================================
 
 export const Curve = {
+  fitCubic,
+
   // ============================================
   // Construction
   // ============================================

--- a/packages/geo/src/fitCubic.test.ts
+++ b/packages/geo/src/fitCubic.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import { Curve, type CubicCurve } from "./Curve";
+import { Vec2 } from "./Vec2";
+
+const arch = Curve.cubic({ x: 0, y: 0 }, { x: 0, y: 160 }, { x: 200, y: 160 }, { x: 200, y: 0 });
+const inflection = Curve.cubic(
+  { x: 0, y: 0 },
+  { x: 50, y: 150 },
+  { x: 150, y: -150 },
+  { x: 200, y: 0 },
+);
+
+function maximumError(original: CubicCurve, fitted: CubicCurve): number {
+  // Exhaustive polyline distance is independent of the Newton projection used
+  // by fitting and hit testing, including on loops and near zero derivatives.
+  return Math.max(
+    ...[
+      [original, fitted],
+      [fitted, original],
+    ].flatMap(([source, target]) => {
+      const polygon = Curve.sample(target, 2048);
+      const edges = polygon.slice(1).map((point, index) => Curve.line(polygon[index], point));
+      return Curve.sample(source, 100).map((point) =>
+        Math.min(...edges.map((edge) => Curve.distanceTo(edge, point))),
+      );
+    }),
+  );
+}
+
+describe("one cubic approximates the original connected span", () => {
+  it.each([0.17, 0.5, 0.83])("recovers an arch split at %s", (t) => {
+    const fitted = Curve.fitCubic(Curve.splitAt(arch, t));
+    expect(fitted.p0).toEqual(arch.p0);
+    expect(fitted.p1).toEqual(arch.p1);
+    expect(maximumError(arch, fitted)).toBeLessThan(0.1);
+    expect(Vec2.cross(Curve.tangentAt(arch, 0), Curve.tangentAt(fitted, 0))).toBeCloseTo(0);
+    expect(Vec2.cross(Curve.tangentAt(arch, 1), Curve.tangentAt(fitted, 1))).toBeCloseTo(0);
+  });
+
+  it("recovers an inflection without jumping to another curve branch", () => {
+    const fitted = Curve.fitCubic(Curve.splitAt(inflection, 0.37));
+    expect(maximumError(inflection, fitted)).toBeLessThan(0.1);
+    expect(Vec2.dot(Curve.tangentAt(inflection, 0), Curve.tangentAt(fitted, 0))).toBeGreaterThan(0);
+  });
+
+  it("fits several segments together instead of successively fitting pairs", () => {
+    const [left, right] = Curve.splitAt(arch, 0.4);
+    const fitted = Curve.fitCubic([...Curve.splitAt(left, 0.3), ...Curve.splitAt(right, 0.6)]);
+    expect(maximumError(arch, fitted)).toBeLessThan(0.1);
+  });
+
+  it("preserves a single cubic exactly", () => {
+    expect(Curve.fitCubic([inflection])).toEqual(inflection);
+  });
+
+  it("keeps a collinear span on its line", () => {
+    const fitted = Curve.fitCubic([
+      Curve.line({ x: 0, y: 0 }, { x: 25, y: 0 }),
+      Curve.line({ x: 25, y: 0 }, { x: 100, y: 0 }),
+    ]);
+    expect(
+      Curve.sample(fitted, 10).every((point) => point.y === 0 && point.x >= 0 && point.x <= 100),
+    ).toBe(true);
+    expect(fitted.p1).toEqual({ x: 100, y: 0 });
+  });
+
+  it("returns finite controls for a singular solve with parallel tangent rays", () => {
+    const fitted = Curve.fitCubic([
+      Curve.cubic({ x: 0, y: 0 }, { x: 80, y: 0 }, { x: 20, y: 100 }, { x: 50, y: 100 }),
+      Curve.cubic({ x: 50, y: 100 }, { x: 80, y: 100 }, { x: 20, y: 0 }, { x: 100, y: 0 }),
+    ]);
+    expect([fitted.c0.x, fitted.c0.y, fitted.c1.x, fitted.c1.y].every(Number.isFinite)).toBe(true);
+    expect(fitted.c0.y).toBe(0);
+    expect(fitted.c1.y).toBe(0);
+  });
+
+  it("derives endpoint directions when authored handles have zero length", () => {
+    const original = Curve.cubic(
+      { x: 0, y: 0 },
+      { x: 0, y: 0 },
+      { x: 100, y: 100 },
+      { x: 100, y: 100 },
+    );
+    const fitted = Curve.fitCubic(Curve.splitAt(original, 0.5));
+    expect(maximumError(original, fitted)).toBeLessThan(0.1);
+    expect(fitted.c0.x).toBeCloseTo(fitted.c0.y);
+    expect(fitted.c1.x).toBeCloseTo(fitted.c1.y);
+  });
+
+  it("retains tangent directions from tiny nonzero endpoint handles", () => {
+    const original = Curve.cubic(
+      { x: 0, y: 0 },
+      { x: 1e-8, y: 0 },
+      { x: 200, y: 100 },
+      { x: 200, y: 0 },
+    );
+    const fitted = Curve.fitCubic(Curve.splitAt(original, 0.5));
+    expect(fitted.c0.x).toBeGreaterThan(0);
+    expect(fitted.c0.y).toBe(0);
+    expect(fitted.c1.x).toBe(200);
+    expect(fitted.c1.y).toBeGreaterThan(0);
+    expect(maximumError(original, fitted)).toBeLessThan(0.1);
+  });
+
+  it("ignores collapsed segments without losing the nonempty span", () => {
+    const fitted = Curve.fitCubic([
+      Curve.line(arch.p0, arch.p0),
+      ...Curve.splitAt(arch, 0.5),
+      Curve.line(arch.p1, arch.p1),
+    ]);
+    expect(maximumError(arch, fitted)).toBeLessThan(0.1);
+  });
+
+  it("fits the same geometry when traversal is reversed", () => {
+    const reversed = Curve.cubic(inflection.p1, inflection.c1, inflection.c0, inflection.p0);
+    const forward = Curve.fitCubic(Curve.splitAt(inflection, 0.37));
+    const backward = Curve.fitCubic(Curve.splitAt(reversed, 0.63));
+    expect(Vec2.dist(forward.c0, backward.c1)).toBeLessThan(1e-6);
+    expect(Vec2.dist(forward.c1, backward.c0)).toBeLessThan(1e-6);
+  });
+
+  it("does not collapse a nonempty loop whose endpoints coincide", () => {
+    const loop = Curve.cubic(
+      { x: 0, y: 0 },
+      { x: 150, y: 200 },
+      { x: -150, y: 200 },
+      { x: 0, y: 0 },
+    );
+    const fitted = Curve.fitCubic(Curve.splitAt(loop, 0.5));
+    expect(Vec2.dist(fitted.c0, loop.c0)).toBeLessThan(0.001);
+    expect(Vec2.dist(fitted.c1, loop.c1)).toBeLessThan(0.001);
+    expect(Curve.length(fitted)).toBeGreaterThan(100);
+  });
+
+  it("returns a collapsed cubic for coincident source geometry", () => {
+    const point = { x: 15, y: 25 };
+    expect(Curve.fitCubic([Curve.line(point, point), Curve.line(point, point)])).toEqual(
+      Curve.cubic(point, point, point, point),
+    );
+  });
+
+  it.each([1e-6, 1e6])("normalizes the solve at scale %s", (scale) => {
+    const offset = { x: 5000, y: -7000 };
+    const original = Curve.cubic(
+      Vec2.scale(Vec2.add(arch.p0, offset), scale),
+      Vec2.scale(Vec2.add(arch.c0, offset), scale),
+      Vec2.scale(Vec2.add(arch.c1, offset), scale),
+      Vec2.scale(Vec2.add(arch.p1, offset), scale),
+    );
+    const fitted = Curve.fitCubic(Curve.splitAt(original, 0.37));
+    expect(Vec2.dist(fitted.c0, original.c0) / scale).toBeLessThan(0.5);
+    expect(Vec2.dist(fitted.c1, original.c1) / scale).toBeLessThan(0.5);
+  });
+
+  it("rejects empty, disconnected and nonfinite input", () => {
+    expect(() => Curve.fitCubic([])).toThrow(RangeError);
+    expect(() => Curve.fitCubic([arch, arch])).toThrow(RangeError);
+    expect(() => Curve.fitCubic([Curve.line({ x: NaN, y: 0 }, { x: 0, y: 0 })])).toThrow(
+      RangeError,
+    );
+  });
+});

--- a/packages/geo/src/fitCubic.ts
+++ b/packages/geo/src/fitCubic.ts
@@ -1,0 +1,235 @@
+import { Curve, type CubicCurve, type CurveType } from "./Curve";
+import type { Point2D } from "./types";
+import { Vec2 } from "./Vec2";
+
+/**
+ * Approximates a connected curve span with one endpoint-tangent-constrained cubic.
+ *
+ * @remarks
+ * Fits from the original geometry without mutating it or subdividing the result.
+ * Sample parameters remain ordered during refinement. Coordinates are normalized
+ * for the solve; surviving endpoints are returned exactly. A poor fit retains
+ * the best finite candidate, with handle lengths bounded by twice the sampled
+ * source length. Zero endpoint derivatives use the first nonzero control-polygon
+ * direction, and a collapsed span returns a collapsed cubic.
+ *
+ * @param curves - Nonempty, connected curves in traversal order with finite coordinates.
+ * @returns One new cubic approximating the whole span in the input coordinate space.
+ * @throws {RangeError} When the input is empty, disconnected, or nonfinite.
+ */
+export function fitCubic(curves: readonly CurveType[]): CubicCurve {
+  if (curves.length === 0) throw new RangeError("fitCubic requires a nonempty curve span");
+
+  const polygon: Point2D[] = [];
+  for (const [index, curve] of curves.entries()) {
+    if (index > 0 && !Vec2.equals(curves[index - 1].p1, curve.p0)) {
+      throw new RangeError("fitCubic requires connected curves");
+    }
+
+    switch (curve.type) {
+      case "line":
+        polygon.push(curve.p0, curve.p1);
+        break;
+      case "quadratic":
+        polygon.push(curve.p0, curve.c, curve.p1);
+        break;
+      case "cubic":
+        polygon.push(curve.p0, curve.c0, curve.c1, curve.p1);
+        break;
+    }
+  }
+
+  if (polygon.some((point) => !Number.isFinite(point.x) || !Number.isFinite(point.y))) {
+    throw new RangeError("fitCubic requires finite coordinates");
+  }
+
+  const first = curves[0];
+  const last = curves[curves.length - 1];
+  if (curves.length === 1) {
+    switch (first.type) {
+      case "cubic":
+        return Curve.cubic(first.p0, first.c0, first.c1, first.p1);
+      case "quadratic":
+        return Curve.quadraticToCubic(first);
+      case "line":
+        return Curve.cubic(
+          first.p0,
+          Vec2.lerp(first.p0, first.p1, 1 / 3),
+          Vec2.lerp(first.p0, first.p1, 2 / 3),
+          first.p1,
+        );
+    }
+  }
+
+  const samples = [first.p0];
+  for (const curve of curves) samples.push(...Curve.sample(curve, 32).slice(1));
+
+  const distances = samples.map((point, index) =>
+    index === 0 ? 0 : Vec2.dist(point, samples[index - 1]),
+  );
+  const length = distances.reduce((sum, distance) => sum + distance, 0);
+  if (length === 0) return Curve.cubic(first.p0, first.p0, last.p1, last.p1);
+  if (!Number.isFinite(length))
+    throw new RangeError("fitCubic span exceeds finite coordinate range");
+
+  const points = samples.map((point) => Vec2.scale(Vec2.sub(point, first.p0), 1 / length));
+  const start = points[0];
+  const end = points[points.length - 1];
+  const startDirection = polygon
+    .map((point) => Vec2.scale(Vec2.sub(point, first.p0), 1 / length))
+    .find((direction) => Vec2.len(direction) > 0);
+  const endDirection = [...polygon]
+    .reverse()
+    .map((point) => Vec2.scale(Vec2.sub(point, last.p1), 1 / length))
+    .find((direction) => Vec2.len(direction) > 0);
+  // These directions have already been checked for zero. Normalizing with a
+  // geometric epsilon would erase the direction of a short but authored handle.
+  const startTangent = startDirection
+    ? {
+        x: startDirection.x / Vec2.len(startDirection),
+        y: startDirection.y / Vec2.len(startDirection),
+      }
+    : Vec2.normalize(Vec2.sub(end, start));
+  const endTangent = endDirection
+    ? { x: endDirection.x / Vec2.len(endDirection), y: endDirection.y / Vec2.len(endDirection) }
+    : Vec2.normalize(Vec2.sub(start, end));
+  const weights = distances.map(
+    (distance, index) => (distance + (distances[index + 1] ?? 0)) / (2 * length),
+  );
+  let distance = 0;
+  let parameters = distances.map((step) => {
+    distance += step;
+    return distance / length;
+  });
+  parameters[parameters.length - 1] = 1;
+
+  let best = Curve.cubic(
+    start,
+    Vec2.add(start, Vec2.scale(startTangent, 1 / 3)),
+    Vec2.add(end, Vec2.scale(endTangent, 1 / 3)),
+    end,
+  );
+  let bestError = Infinity;
+
+  for (let iteration = 0; iteration < 80; iteration++) {
+    let aa = 0;
+    let ab = 0;
+    let bb = 0;
+    let ar = 0;
+    let br = 0;
+
+    for (let index = 1; index < points.length - 1; index++) {
+      const t = parameters[index];
+      const a = Vec2.scale(startTangent, 3 * (1 - t) ** 2 * t);
+      const b = Vec2.scale(endTangent, 3 * (1 - t) * t ** 2);
+      const base = Vec2.lerp(start, end, t ** 3 + 3 * (1 - t) * t ** 2);
+      const residual = Vec2.sub(points[index], base);
+      const weight = weights[index];
+      aa += weight * Vec2.dot(a, a);
+      ab += weight * Vec2.dot(a, b);
+      bb += weight * Vec2.dot(b, b);
+      ar += weight * Vec2.dot(a, residual);
+      br += weight * Vec2.dot(b, residual);
+    }
+
+    // Solve the box-constrained two-variable least-squares problem: its
+    // minimum is either the unconstrained solution or on one of four edges.
+    const candidates = [[1 / 3, 1 / 3]];
+    const determinant = aa * bb - ab * ab;
+    if (determinant > 1e-12 * aa * bb) {
+      candidates.push([(ar * bb - br * ab) / determinant, (br * aa - ar * ab) / determinant]);
+    }
+    for (const bound of [1e-8, 2]) {
+      candidates.push([
+        bound,
+        Math.max(1e-8, Math.min(2, bb > 0 ? (br - ab * bound) / bb : 1 / 3)),
+      ]);
+      candidates.push([
+        Math.max(1e-8, Math.min(2, aa > 0 ? (ar - ab * bound) / aa : 1 / 3)),
+        bound,
+      ]);
+    }
+
+    let curve = best;
+    let error = Infinity;
+    for (const [alpha, beta] of candidates) {
+      if (
+        !Number.isFinite(alpha) ||
+        !Number.isFinite(beta) ||
+        alpha < 1e-8 ||
+        beta < 1e-8 ||
+        alpha > 2 ||
+        beta > 2
+      )
+        continue;
+
+      const candidate = Curve.cubic(
+        start,
+        Vec2.add(start, Vec2.scale(startTangent, alpha)),
+        Vec2.add(end, Vec2.scale(endTangent, beta)),
+        end,
+      );
+      const candidateError = points.reduce(
+        (sum, point, index) =>
+          sum + weights[index] * Vec2.distSq(point, Curve.pointAt(candidate, parameters[index])),
+        0,
+      );
+      if (candidateError < error) {
+        error = candidateError;
+        curve = candidate;
+      }
+    }
+
+    if (error < bestError) {
+      bestError = error;
+      best = curve;
+    }
+    if (error < 1e-18) break;
+
+    // Safeguarded Newton projection. Each sample stays inside its own ordered
+    // interval; accepting only improvements avoids branch jumps on S-curves.
+    const next = [...parameters];
+    let movement = 0;
+    for (let index = 1; index < points.length - 1; index++) {
+      const t = parameters[index];
+      const residual = Vec2.sub(Curve.pointAt(curve, t), points[index]);
+      const derivative = Curve.tangentAt(curve, t);
+      const secondDerivative = Vec2.scale(
+        Vec2.lerp(
+          Vec2.add(Vec2.sub(curve.c1, Vec2.scale(curve.c0, 2)), curve.p0),
+          Vec2.add(Vec2.sub(curve.p1, Vec2.scale(curve.c1, 2)), curve.c0),
+          t,
+        ),
+        6,
+      );
+      const denominator = Vec2.dot(derivative, derivative) + Vec2.dot(residual, secondDerivative);
+      if (Math.abs(denominator) < 1e-14) continue;
+
+      const lower = (parameters[index - 1] + t) / 2;
+      const upper = (t + parameters[index + 1]) / 2;
+      let updated = Math.max(
+        lower,
+        Math.min(upper, t - Vec2.dot(residual, derivative) / denominator),
+      );
+      for (let step = 0; step < 8; step++) {
+        if (Vec2.distSq(Curve.pointAt(curve, updated), points[index]) <= Vec2.lenSq(residual))
+          break;
+        updated = (updated + t) / 2;
+      }
+      if (Vec2.distSq(Curve.pointAt(curve, updated), points[index]) > Vec2.lenSq(residual))
+        continue;
+
+      next[index] = updated;
+      movement = Math.max(movement, Math.abs(updated - t));
+    }
+    parameters = next;
+    if (movement < 1e-12) break;
+  }
+
+  return Curve.cubic(
+    first.p0,
+    Vec2.add(first.p0, Vec2.scale(best.c0, length)),
+    Vec2.add(first.p0, Vec2.scale(best.c1, length)),
+    last.p1,
+  );
+}


### PR DESCRIPTION
## Summary

- Add `Curve.fitCubic` to approximate a connected span with one cubic while retaining endpoints and available tangent directions.
- Solve bounded least squares for the two control lengths and use ordered, safeguarded Newton refinement. Handle singular solves, collapsed spans, tiny handles, inflections and coincident endpoints.
- Add 17 numerical regression cases with an independent exhaustive-polyline accuracy check.

This is the geometry prerequisite for curve-aware deletion; it does not change editor behavior by itself. Module-documentation updates follow in a separate stacked PR.

## Issue

Refs #352

## Testing

Passed:
- `pnpm test --filter=@shift/geo` — 182 tests.
- Commit hooks on the isolated geometry change: formatting, lint, standard typecheck, strict dead-code checks and the full test suite.

No desktop interaction changes in this layer; keyboard, native-menu, rendering and save/reopen E2E are exercised by the dependent editor PR.

## Risks

This is a best-effort one-cubic approximation, not a guaranteed tolerance-bound simplifier. Handle lengths are bounded by twice the sampled source length; the result never recursively inserts on-curve points.
