### PR TITLE
docs: document curve deletion and refresh module contracts

### DIFF
--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -31,7 +31,7 @@ src/main/
   AsyncOnce.ts                    -- resettable retained asynchronous one-shot
   release.ts                      -- compiled distribution identity and product name
   about/
-    AboutWindow.ts                -- singleton custom-chrome product information window
+    AboutWindow.ts                -- singleton product information window
   feedback/
     FeedbackWindow.ts             -- singleton modeless feedback composer window
   app/
@@ -53,7 +53,7 @@ src/main/
     ApplicationMenu.ts            -- Electron application menu
   update/
     AppUpdater.ts                  -- update orchestration, scheduling, consent, and restart safety
-    UpdateWindow.ts                -- custom-chrome download progress and install prompt window
+    UpdateWindow.ts                -- download progress and install prompt window
     types.ts                       -- update status and feed contracts
     updateFeed.ts                  -- pure native feed selection
   windows/
@@ -78,7 +78,7 @@ src/main/
 - `DocumentSession` -- native document workflow for Save, Save As, Export TrueType, and close confirmation.
 - `AppLifecycle` -- coordinates Electron window close, app quit, and update restart around document vetoes.
 - `AppUpdater` -- main-process owner of native feed selection, Electron auto-update events, consent, cancellation, and restart safety.
-- `UpdateWindow` -- custom-chrome renderer of download progress and ready-to-install choices.
+- `UpdateWindow` -- renderer of download progress and ready-to-install choices.
 - `FeedbackWindow` -- singleton modeless composer that routes user-authored feedback to email, GitHub, or Discord without collecting files or diagnostics.
 - `UpdateStatus` -- updater lifecycle: idle, checking, available, downloading, ready, or restarting.
 - `WorkspaceDocumentState` -- utility-owned lifecycle state mirrored into main and renderer.
@@ -111,7 +111,7 @@ Eligible packaged macOS builds and Windows Nightly x64 builds start `AppUpdater`
 
 `AppUpdater.checkForUpdates(trigger)` derives a fixed HTTPS generic-provider URL from the compiled Release or Nightly distribution and exact platform/architecture. electron-updater reads architecture-specific `latest-mac.yml` on macOS and `latest.yml` for Windows Nightly. It owns numeric version comparison, SHA-512 verification, download, macOS code-signature verification, Authenticode verification when configured, installation, and relaunch. Release and Nightly never share feed paths.
 
-Automatic current/error results stay quiet. When a check finds an update, the custom-chrome update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. A preparation or workspace-close failure blocks installation, remains technical in the log, and presents actionable document-save guidance rather than workspace internals. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
+Automatic current/error results stay quiet. When a check finds an update, the update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. A preparation or workspace-close failure blocks installation, remains technical in the log, and presents actionable document-save guidance rather than workspace internals. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
 
 The application menu exposes `app.checkForUpdates` under the macOS app menu and the Windows/Linux Help menu. Every platform's Help menu also opens the Shift website, Discord, and X account. Its adjacent support actions open the dedicated public Bug report form, reveal electron-log's active file in the platform file manager, or open a singleton modeless feedback composer. The composer retains its draft while open and routes only user-authored text to the mail client; GitHub and the Discord feedback channel remain explicit alternatives. Closing discards the draft. Users review and attach logs manually; Shift does not read or upload their files. Update behavior remains main-owned and does not add renderer IPC.
 

--- a/apps/desktop/src/main/docs/DOCS.md
+++ b/apps/desktop/src/main/docs/DOCS.md
@@ -31,7 +31,7 @@ src/main/
   AsyncOnce.ts                    -- resettable retained asynchronous one-shot
   release.ts                      -- compiled distribution identity and product name
   about/
-    AboutWindow.ts                -- singleton native-framed product information window
+    AboutWindow.ts                -- singleton custom-chrome product information window
   feedback/
     FeedbackWindow.ts             -- singleton modeless feedback composer window
   app/
@@ -53,7 +53,7 @@ src/main/
     ApplicationMenu.ts            -- Electron application menu
   update/
     AppUpdater.ts                  -- update orchestration, scheduling, consent, and restart safety
-    UpdateWindow.ts                -- native-framed download progress and install prompt window
+    UpdateWindow.ts                -- custom-chrome download progress and install prompt window
     types.ts                       -- update status and feed contracts
     updateFeed.ts                  -- pure native feed selection
   windows/
@@ -78,7 +78,7 @@ src/main/
 - `DocumentSession` -- native document workflow for Save, Save As, Export TrueType, and close confirmation.
 - `AppLifecycle` -- coordinates Electron window close, app quit, and update restart around document vetoes.
 - `AppUpdater` -- main-process owner of native feed selection, Electron auto-update events, consent, cancellation, and restart safety.
-- `UpdateWindow` -- native-framed renderer of download progress and ready-to-install choices.
+- `UpdateWindow` -- custom-chrome renderer of download progress and ready-to-install choices.
 - `FeedbackWindow` -- singleton modeless composer that routes user-authored feedback to email, GitHub, or Discord without collecting files or diagnostics.
 - `UpdateStatus` -- updater lifecycle: idle, checking, available, downloading, ready, or restarting.
 - `WorkspaceDocumentState` -- utility-owned lifecycle state mirrored into main and renderer.
@@ -111,7 +111,7 @@ Eligible packaged macOS builds and Windows Nightly x64 builds start `AppUpdater`
 
 `AppUpdater.checkForUpdates(trigger)` derives a fixed HTTPS generic-provider URL from the compiled Release or Nightly distribution and exact platform/architecture. electron-updater reads architecture-specific `latest-mac.yml` on macOS and `latest.yml` for Windows Nightly. It owns numeric version comparison, SHA-512 verification, download, macOS code-signature verification, Authenticode verification when configured, installation, and relaunch. Release and Nightly never share feed paths.
 
-Automatic current/error results stay quiet. When a check finds an update, the native-framed update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. A preparation or workspace-close failure blocks installation, remains technical in the log, and presents actionable document-save guidance rather than workspace internals. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
+Automatic current/error results stay quiet. When a check finds an update, the custom-chrome update window offers **Download Update** / Later; declining leaves the version available without prompting again during periodic checks. An accepted download replaces those choices with cumulative progress. Closing the window or choosing Cancel cancels the transfer and returns to available. Download completion replaces progress with **Restart and Install** / Later, and a manual check while available or ready reopens the relevant choice. Later retains a verified download without silently installing it on ordinary quit. Restart prepares every document, cancels all prepared closes if one vetoes, commits every agreed close, and only then calls `quitAndInstall()`. A preparation or workspace-close failure blocks installation, remains technical in the log, and presents actionable document-save guidance rather than workspace internals. Electron closes windows before normal `before-quit`, so `AppLifecycle`'s `confirmed` state allows those closes. An install failure after commit relaunches the currently installed application; closed in-memory sessions are never reconstructed.
 
 The application menu exposes `app.checkForUpdates` under the macOS app menu and the Windows/Linux Help menu. Every platform's Help menu also opens the Shift website, Discord, and X account. Its adjacent support actions open the dedicated public Bug report form, reveal electron-log's active file in the platform file manager, or open a singleton modeless feedback composer. The composer retains its draft while open and routes only user-authored text to the mail client; GitHub and the Discord feedback channel remain explicit alternatives. Closing discards the draft. Users review and attach logs manually; Shift does not read or upload their files. Update behavior remains main-owned and does not add renderer IPC.
 
@@ -173,8 +173,8 @@ Renderer IPC in `App` is limited to shell capabilities: command execution, nativ
 
 ## Verification
 
-- `pnpm --filter @shift/desktop test src/utility/workspace/WorkspaceHost.test.ts`
-- `pnpm --filter @shift/desktop test src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts`
+- `pnpm test:desktop src/utility/workspace/WorkspaceHost.test.ts`
+- `pnpm test:desktop src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts`
 - `pnpm typecheck`
 - `pnpm test:desktop src/main/AsyncOnce.test.ts src/main/document/DocumentSession.test.ts src/main/app/AppLifecycle.test.ts`
 - `pnpm test:desktop src/main/update/updateFeed.test.ts`

--- a/apps/desktop/src/preload/docs/DOCS.md
+++ b/apps/desktop/src/preload/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Preload
 
-<!-- reviewed: 2026-08-27 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Electron preload script that exposes the typed Shift host API and relays session ports to the renderer.
 
@@ -19,7 +19,7 @@ preload/
 
 ## Key Types
 
-- `ShiftHost` -- renderer-facing app-shell API for commands, native menus, documents, sessions, application updates, UI events, and clipboard access.
+- `ShiftHost` -- renderer-facing app-shell API for commands, native menus, documents, sessions, application updates, document-window reconstruction, renderer error reporting, UI events, and clipboard access.
 - `RendererToMain` -- renderer-to-main request/response channel map.
 - `MainToRenderer` -- main-to-renderer broadcast channel map.
 
@@ -27,7 +27,7 @@ preload/
 
 The preload runs once before the renderer loads:
 
-1. Builds `ShiftHost` methods from typed `invoke` and `listen` IPC helpers, including native context-menu requests and update-window progress and actions.
+1. Builds `ShiftHost` methods from typed `invoke` and `listen` IPC helpers, including native context-menu requests, update-window progress and actions, privacy-safe renderer error reports, and document-window reconstruction without clearing recovery state.
 2. Exposes that object as `window.shiftHost` through `contextBridge`.
 3. Relays session and document `MessagePort`s into the page. Because packaged `file://` pages have opaque origins, receivers authenticate these relays with `event.source === window` plus the expected message type rather than comparing origin strings.
 

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -136,7 +136,7 @@ Paste selects inserted objects and activates Select before awaiting the workspac
 
 ### Deletion
 
-`Editor.deleteSelection(mode)` normalizes point, segment, and contour selection against the active authored layer and delegates to `GlyphLayer.deletePoints`. Delete and Backspace use `"fit"`; Shift selects `"gap"`. Native-menu Delete uses the default fitted behavior. Selecting a segment is equivalent to selecting all of its points. Unsupported, missing, or mixed-anchor selections refuse without mutation. Successful deletion clears selection and hover and awaits the workspace echo; the entire geometry edit is one undo step.
+`Editor.deleteSelection(mode)` normalizes point, segment, and contour selection against the active authored layer and delegates to `GlyphLayer.deletePoints`. Delete and Backspace use `"fit"`; Shift selects `"gap"`. Native-menu Delete uses the same default reconnection behavior. Reconnection never raises the original span's highest degree: lines stay lines, quadratic/line mixtures stay quadratic, and spans containing cubics are fitted as cubics. Selecting a segment is equivalent to selecting all of its points. Unsupported, missing, or mixed-anchor selections refuse without mutation. Successful deletion clears selection and hover and awaits the workspace echo; the entire geometry edit is one undo step.
 
 ### Hit testing
 
@@ -178,10 +178,10 @@ Glyph geometry exposes domain hit queries for points, anchors, and segments. Too
 
 - `pnpm test:desktop src/renderer/src/lib/editor/` -- real-editor tests for managers, hit testing, sidebearings, lifecycle, plus editor-outcome suites for boolean operations, clipboard copy/paste, and glyph metrics that drive `TestEditor` through real tool gestures and assert resulting contours, selection, and history.
 - Outcome tests treat editor actions as asynchronous: metric setters need `await editor.settle()` before asserting, clipboard and history actions (`copy`, `paste`, `undo`, `redo`) return promises that must be awaited, and drag helpers give every drag sample its cumulative delta from the pointer-down origin.
-- [Deletion behavior](../Deletion.test.ts), [contour topology](../DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) cover fitted/gap deletion, exact undo/redo, and saved geometry. Run them and the real-canvas Electron suite with:
+- [Deletion behavior](../Deletion.test.ts), [degree preservation](../DeletionDegree.test.ts), [contour topology](../DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) cover fitted/gap deletion, exact undo/redo, and saved geometry. Run them and the real-canvas Electron suite with:
 
   ```bash
-  pnpm test:desktop src/renderer/src/lib/editor/Deletion.test.ts src/renderer/src/lib/editor/DeletionTopology.test.ts src/renderer/src/lib/workspace/FreshReopen.test.ts
+  pnpm test:desktop src/renderer/src/lib/editor/Deletion.test.ts src/renderer/src/lib/editor/DeletionDegree.test.ts src/renderer/src/lib/editor/DeletionTopology.test.ts src/renderer/src/lib/workspace/FreshReopen.test.ts
   pnpm test:e2e:visual e2e/deletion.spec.ts
   ```
 

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Editor
 
-<!-- reviewed: 2026-09-04 -->
+<!-- reviewed: 2026-09-05 -->
 
 Central orchestrator for the canvas-based glyph editing surface, wiring viewport transforms, selection, rendering, hit testing, and tool management into a single facade.
 
@@ -30,7 +30,7 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** `Editor.toolCell` is the public active-tool state surface. It derives `{ id, state }` from the active tool instance and its `stateCell`; consumers use `toolIf(id)` for built-in state narrowing and do not reach through `ToolManager` for active state. Entering or leaving a glyph route resets the active tool instance, selection, hover, and editing scope so transient interaction state cannot cross glyphs.
 
-**Architecture Invariant:** `ToolManager` is authoritative for installed manifests. `Editor.toolRegistryCell` derives reactive toolbar metadata from that collection, and `registerTool()` returns the `ToolRegistration` that exclusively owns replacement and removal of the contributed ID.
+**Architecture Invariant:** `ToolManager` is authoritative for installed manifests. `Editor.toolRegistryCell` derives reactive toolbar metadata, including hidden and disabled flags, from that collection. Both flags suppress user tool shortcuts while preserving programmatic activation, and `registerTool()` returns the `ToolRegistration` that exclusively owns replacement and removal of the contributed ID.
 
 **Architecture Invariant:** Camera and text-layout metrics resolve from the active design location through `Font.metricsAtLocation()`. Exact master locations use authored source values; intermediate locations evaluate the Rust-built source-metric interpolation model. Glyph navigation preserves one stable UPM scale and origin rather than fitting each outline independently; empty, narrow, wide, and extreme glyphs therefore retain comparable editing scale.
 
@@ -110,7 +110,7 @@ Tools receive screen and scene coordinates from the pointer pipeline. Scene/node
 | background | Canvas 2D    | Guides, tool backgrounds                                    | `#backgroundEffect`               |
 | scene      | Canvas 2D    | Glyph outline, segments, handles (CPU), anchors, tool scene | `#sceneEffect`                    |
 | handles    | WebGL (regl) | GPU-rendered point handles                                  | `#sceneEffect` (via scene render) |
-| overlay    | Canvas 2D    | Bounding box handles, tool overlays                         | `#overlayEffect`                  |
+| overlay    | Canvas 2D    | Bounding box outline, tool overlays                         | `#overlayEffect`                  |
 
 Background, scene, and overlays are drawn in UPM space (`Canvas.withSceneSpace()` applies the affine transform). Tool-owned controls convert pixel-sized handles and strokes at draw time.
 
@@ -118,7 +118,7 @@ Background, scene, and overlays are drawn in UPM space (`Canvas.withSceneSpace()
 
 `Renderer.#renderScene()` draws `SceneLayer`, which runs three passes over the scene nodes:
 
-1. Content pass -- `GlyphNodeDefinition` draws a stroked outline plus debug overlays (if enabled) while the glyph is being edited; a non-editing glyph takes the display path and draws a filled outline instead.
+1. Content pass -- `GlyphNodeDefinition` draws distinct translucent fills for closed root and component contours, stroked outlines, and optional debug overlays while editing. Display rendering fills closed contours and strokes open contours; it never implicitly fills an open gap.
 2. Delegates to `ToolManager.drawScene()` inside each glyph node's transform.
 3. Controls pass -- draws hovered/selected segments, then control lines with frustum culling via `Camera.visibleSceneBounds()`, then handles (GPU marker rendering with CPU fallback), then anchors.
 
@@ -129,6 +129,14 @@ Background, scene, and overlays are drawn in UPM space (`Canvas.withSceneSpace()
 ### Position selection boundary
 
 `Editor.positionSelection(ids)` resolves points and anchors directly, expands selected segments and contours to points, and verifies that every target belongs to the active authored layer. Select-tool behaviors pass the returned targets to `GlyphLayer.positions.move`, `.rotate`, or `.scale`; scene-space gesture calculations remain in the tool layer.
+
+### Editing result selection
+
+Paste selects inserted objects and activates Select before awaiting the workspace echo. Boolean operations await their committed geometry and select every newly created result contour, including an empty selection when the result has no contours.
+
+### Deletion
+
+`Editor.deleteSelection(mode)` normalizes point, segment, and contour selection against the active authored layer and delegates to `GlyphLayer.deletePoints`. Delete and Backspace use `"fit"`; Shift selects `"gap"`. Native-menu Delete uses the default fitted behavior. Selecting a segment is equivalent to selecting all of its points. Unsupported, missing, or mixed-anchor selections refuse without mutation. Successful deletion clears selection and hover and awaits the workspace echo; the entire geometry edit is one undo step.
 
 ### Hit testing
 
@@ -168,8 +176,15 @@ Glyph geometry exposes domain hit queries for points, anchors, and segments. Too
 
 ## Verification
 
-- `npx vitest run apps/desktop/src/renderer/src/lib/editor/` -- unit tests for managers, hit testing, sidebearings, lifecycle, plus editor-outcome suites for boolean operations, clipboard copy/paste, and glyph metrics that drive `TestEditor` through real tool gestures and assert resulting contours, selection, and history.
+- `pnpm test:desktop src/renderer/src/lib/editor/` -- real-editor tests for managers, hit testing, sidebearings, lifecycle, plus editor-outcome suites for boolean operations, clipboard copy/paste, and glyph metrics that drive `TestEditor` through real tool gestures and assert resulting contours, selection, and history.
 - Outcome tests treat editor actions as asynchronous: metric setters need `await editor.settle()` before asserting, clipboard and history actions (`copy`, `paste`, `undo`, `redo`) return promises that must be awaited, and drag helpers give every drag sample its cumulative delta from the pointer-down origin.
+- [Deletion behavior](../Deletion.test.ts), [contour topology](../DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) cover fitted/gap deletion, exact undo/redo, and saved geometry. Run them and the real-canvas Electron suite with:
+
+  ```bash
+  pnpm test:desktop src/renderer/src/lib/editor/Deletion.test.ts src/renderer/src/lib/editor/DeletionTopology.test.ts src/renderer/src/lib/workspace/FreshReopen.test.ts
+  pnpm test:e2e:visual e2e/deletion.spec.ts
+  ```
+
 - `pnpm test:desktop src/renderer/src/lib/model/positions/PositionEdits.test.ts` -- position-edit (move/rotate/scale) tests.
 - `pnpm test:desktop src/renderer/src/lib/editor/managers/Camera.test.ts` -- camera manager tests.
 - `pnpm test:e2e:visual e2e/glyph-navigation.spec.ts e2e/glyph-view.spec.ts e2e/tools.spec.ts` -- stale/transient navigation, stable UPM framing, and DOM cancellation evidence.

--- a/apps/desktop/src/renderer/src/lib/graphics/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/graphics/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Graphics
 
-<!-- reviewed: 2026-09-04 -->
+<!-- reviewed: 2026-09-05 -->
 
 Renderer vector-path values and the accelerated marker-layer backend for editor handle drawing.
 

--- a/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
@@ -39,7 +39,7 @@ lib/model/
   FontStore.ts               -- workspace records, authored layer state, projections, canonical Glyph ownership
   Glyph.ts                   -- Glyph, GlyphLayer, internal GlyphRenderModel, root lookup, composed metrics
   GlyphLayerEdit.ts          -- reversible structural edits over the current reactive layer
-  deletePoints.ts            -- contour-aware fitted deletion, gaps, and handle conversion
+  DeletePoints.ts            -- per-operation degree-preserving deletion, gaps, and handle conversion
   ComponentGlyph.ts          -- component and contour occurrence provenance/reactivity
   GlyphLayerState.ts         -- local edit lifecycle and pending confirmation
   positions/                 -- PositionEdits, PositionList, transforms, references, and modifiers
@@ -134,11 +134,11 @@ Local operations mutate the existing segmented `LayerBuffers`: advance, contours
 
 ### Contour-aware deletion
 
-`GlyphLayer.deletePoints(pointIds, mode)` interprets explicit selected point IDs against the original contours and groups all resulting mutations into one workspace transaction. `DeleteMode` is `"fit"` for endpoint-tangent-constrained cubic replacement and `"gap"` for disconnected surviving fragments. Each span between surviving on-curve points is processed once; selected handles within a removed span are consumed by that span's policy, while selected handles outside it convert their segment to a line. Raw `removePoints` remains a separate primitive and clipboard cut behavior is unchanged.
+`GlyphLayer.deletePoints(pointIds, mode)` creates a per-operation `DeletePoints` and calls `apply()` to interpret explicit selected point IDs against the original contours in one workspace transaction. The operation holds the layer, copied selection, and mode; private helpers separate handle removal, original-span traversal, surviving-fragment construction, and identity-preserving contour replacement. `DeleteMode` is `"fit"` for degree-preserving reconnection and `"gap"` for disconnected surviving fragments. Line-only spans join surviving endpoints directly without controls. Spans containing quadratics but no cubics fit one quadratic control with exact endpoints, without constraining endpoint tangents. Only spans containing cubics use endpoint-tangent-constrained cubic fitting. Each span between surviving on-curve points is processed once; selected handles within a removed span are consumed by that span's policy, while selected handles outside it convert their segment to a line. Raw `removePoints` remains a separate primitive and clipboard cut behavior is unchanged.
 
 Closed contours are traversed cyclically, including leading controls belonging to the wrapped segment. Gaps open or split them into valid open fragments. No surviving on-curve points removes the contour; one survivor becomes an open one-point contour. The original contour retains the fragment containing its first surviving on-curve identity; additional fragments receive new contour IDs and append to the layer without reordering unrelated contours. Surviving points keep their IDs and authored values; new fitted controls receive new IDs. A retained point keeps the original contour from being pruned while the other points are reinserted through the existing seeded mutation primitives. Intermediate mutations stay inside the reactive/workspace transaction; the local result and confirmed echo have identical topology.
 
-The [deletion behavior tests](../../editor/Deletion.test.ts), [contour-topology tests](../../editor/DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) verify geometry, identity, cyclic boundaries, refusal, local/confirmed parity, atomic undo/redo, and fresh-workspace persistence through the real editor and native bridge. The deletion Electron E2E suite drives canvas selection, keyboard and native-menu deletion, pixel-level rendering checks, and save/reopen.
+The [deletion behavior tests](../../editor/Deletion.test.ts), [degree-preservation tests](../../editor/DeletionDegree.test.ts), [contour-topology tests](../../editor/DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) verify geometry, identity, cyclic boundaries, refusal, local/confirmed parity, atomic undo/redo, and fresh-workspace persistence through the real editor and native bridge. The deletion Electron E2E suite drives canvas selection, keyboard and native-menu deletion, pixel-level rendering checks, and save/reopen.
 
 ### Packed layout ownership
 

--- a/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/model/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Renderer font model
 
-<!-- reviewed: 2026-08-24 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Reactive TypeScript font, authored glyph-layer, and derived glyph-view surfaces.
 
@@ -14,6 +14,7 @@ Reactive TypeScript font, authored glyph-layer, and derived glyph-view surfaces.
 - **Architecture Invariant:** `GlyphProjection` is plain, location-independent backing owned internally by `FontStore`. It is not an open/ready/loading lifecycle and is not exposed as the renderer's user-facing glyph object.
 - **Architecture Invariant:** One `GlyphRenderModel` follows one location signal. Location changes lazily replace its current computed geometry; Shift never retains a cache keyed by historical location values.
 - **Architecture Invariant:** `GlyphRenderModel.contours` is the complete root-plus-component contour occurrence stream used by rendering, bounds, layout, and sidebearings. A contour's `component` is `null` only when the root glyph owns it.
+- **Architecture Invariant:** Render paths distinguish closed contours from open contours. Root-only and component-owned closed paths support separate editable fills; display rendering fills all closed contours and strokes open contours without implicitly filling gaps.
 - **Architecture Invariant:** A render model shares one evaluated source-contour list per base glyph at its current location. Each component placement owns a distinct `GlyphContour` wrapper for transform and provenance; `GlyphRenderModel.contours` flattens references to those same occurrence objects rather than copying contour coordinates.
 - **Architecture Invariant:** Rust owns component order, ancestry, attachment selection, and cycle pruning through `GlyphComponents`. TypeScript only resolves current coordinates and composes matrices. Component paths preserve authored occurrence identity; numeric transforms are selected by the occurrence's parent-local `componentIndex`, because compatible exact-source layers may assign different `ComponentId` values to corresponding slots.
 - **Architecture Invariant:** Numeric authored edits flow through the existing `GlyphLayerState` signal graph. Do not add a revision signal, invalidate projections to `null`, or refetch native variation data for point, component-transform, advance, or metric value changes.
@@ -38,6 +39,7 @@ lib/model/
   FontStore.ts               -- workspace records, authored layer state, projections, canonical Glyph ownership
   Glyph.ts                   -- Glyph, GlyphLayer, internal GlyphRenderModel, root lookup, composed metrics
   GlyphLayerEdit.ts          -- reversible structural edits over the current reactive layer
+  deletePoints.ts            -- contour-aware fitted deletion, gaps, and handle conversion
   ComponentGlyph.ts          -- component and contour occurrence provenance/reactivity
   GlyphLayerState.ts         -- local edit lifecycle and pending confirmation
   positions/                 -- PositionEdits, PositionList, transforms, references, and modifiers
@@ -129,6 +131,14 @@ Layer edits move through **active** (cancelable), **pending** (finished and queu
 Local operations mutate the existing segmented `LayerBuffers`: advance, contours, anchors, and components. Each logical record owns both the metadata and the `PackedArray` values needed to interpret it. `GlyphStructure` and the flat `Float64Array` are repacked lazily at geometry and wire boundaries. Renderer code does not parse `FontIntent.kind` or perform font-wide validation. While an edit is active, an arriving workspace replacement becomes its latest restoration base and the edit reapplies immediately in the same batch. Each loaded layer otherwise keeps a confirmed shadow only while edits are pending. Every echo advances that shadow, but visible pending geometry is replaced only after the layer's pending identities drain; workspace failure still discards renderer state through the existing full resync.
 
 `GlyphLayerState.#applyEdit()` wraps pending operations. It captures the pre-edit snapshot once per `PendingEditId`, batches a typed operation closure, and records only successful changes. `beginEdit()`, `finishEdit()`, and `cancelEdit()` separately own the active local lifecycle. Their operation closures remain renderer-local and never cross `LayerIntents` or IPC.
+
+### Contour-aware deletion
+
+`GlyphLayer.deletePoints(pointIds, mode)` interprets explicit selected point IDs against the original contours and groups all resulting mutations into one workspace transaction. `DeleteMode` is `"fit"` for endpoint-tangent-constrained cubic replacement and `"gap"` for disconnected surviving fragments. Each span between surviving on-curve points is processed once; selected handles within a removed span are consumed by that span's policy, while selected handles outside it convert their segment to a line. Raw `removePoints` remains a separate primitive and clipboard cut behavior is unchanged.
+
+Closed contours are traversed cyclically, including leading controls belonging to the wrapped segment. Gaps open or split them into valid open fragments. No surviving on-curve points removes the contour; one survivor becomes an open one-point contour. The original contour retains the fragment containing its first surviving on-curve identity; additional fragments receive new contour IDs and append to the layer without reordering unrelated contours. Surviving points keep their IDs and authored values; new fitted controls receive new IDs. A retained point keeps the original contour from being pruned while the other points are reinserted through the existing seeded mutation primitives. Intermediate mutations stay inside the reactive/workspace transaction; the local result and confirmed echo have identical topology.
+
+The [deletion behavior tests](../../editor/Deletion.test.ts), [contour-topology tests](../../editor/DeletionTopology.test.ts), and [fresh-reopen tests](../../workspace/FreshReopen.test.ts) verify geometry, identity, cyclic boundaries, refusal, local/confirmed parity, atomic undo/redo, and fresh-workspace persistence through the real editor and native bridge. The deletion Electron E2E suite drives canvas selection, keyboard and native-menu deletion, pixel-level rendering checks, and save/reopen.
 
 ### Packed layout ownership
 

--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Tools
 
-<!-- reviewed: 2026-09-02 -->
+<!-- reviewed: 2026-09-05 -->
 
 State machine-based tool system for the Shift font editor: translates pointer/keyboard input into tool-specific state transitions and rendering.
 
@@ -53,7 +53,7 @@ tools/
 
 ## Key Types
 
-- `BaseTool<S, Settings>` — abstract base class all tools extend. Declares `id`, `behaviors`, `initialState`. Optional overrides: `preTransition`, `onStateChange`, `getCursor`, `activate`, `deactivate`, `drawOverlay`, `drawScene`, `drawBackground`. Permanent `dispose()` releases base computed signals after deactivation.
+- `BaseTool<S, TTool, Settings>` — abstract base class all tools extend. Declares `id`, `behaviors`, `initialState`. Optional overrides: `preTransition`, `onStateChange`, `getCursor`, `activate`, `deactivate`, `drawOverlay`, `drawScene`, `drawBackground`. Permanent `dispose()` releases base computed signals after deactivation.
 - `Behavior<S, TTool>` — interface with optional per-event handlers (`onClick`, `onDrag`, `onDragStart`, `onDragEnd`, `onDragCancel`, `onPointerMove`, `onDoubleClick`, `onKeyDown`, `onKeyUp`) plus lifecycle hooks (`onStateExit`, `onStateEnter`). Each handler receives `(state, ctx, event)` and returns `boolean` (true = handled).
 - `ToolContext<S, TTool>` — `{ editor, tool, getState, setState, onCancel }`. `tool: TTool` gives class-style behaviors access to their owning tool instance (e.g. `PenStroke.active(ctx.tool)`). `onCancel(callback)` registers rollback for the active drag and returns a function that dismisses it after successful completion.
 - `ToolEvent` — discriminated union of semantic events: `pointerMove`, `click`, `doubleClick`, `dragStart`, `drag`, `dragEnd`, `dragCancel`, `keyDown`, `keyUp`, `selectionChanged`. Pointer events include `coords: Coordinates`.
@@ -144,6 +144,10 @@ After `#runBehaviors`, if `next !== prev` (reference equality):
 Position transforms call `editor.positionSelection(ids)` once at interaction start, then create `selection.layer.positions.move(selection.targets)`, `.rotate(...)`, or `.scale(...)`. The behavior immediately registers `edit.discard()` with `ctx.onCancel()`. Preview methods always resolve from the operation's frozen position base; after `commit()` finishes the active `GlyphLayerEdit`, the behavior calls the returned function to dismiss rollback.
 
 Pen topology and non-affine position patches use `GlyphLayer.beginEdit()` directly and register `edit.cancel()` through the same drag scope. Pen constructs cubic point sequences with the generic `GlyphLayerEdit.addPoints()` primitive; `setPointSmooth()` and `setPositions()` mutate the ordinary reactive layer immediately. `finish(label)` restores the latest accepted base and replays the final operations through one workspace transaction in the same reactive batch; after finishing, the behavior dismisses rollback. An undismissed rollback restores the base without sending an intent.
+
+### Shape completion and selection
+
+On drag end, Shape commits a valid rectangle as one transaction, selects its new contour, and switches to Select. A too-small or unavailable-layer result returns Shape to ready without creating geometry. The Select bounding box draws its outline without visible corner squares; resize and rotation hit zones remain active.
 
 ### Rendering layers
 
@@ -266,7 +270,7 @@ onDragCancel(state, ctx) {
 
 ## Verification
 
-- `pnpm vitest run apps/desktop/src/renderer/src/lib/tools/` — unit tests.
+- `pnpm test:desktop src/renderer/src/lib/tools/` — real-editor tool tests.
 - `GestureDetector.test.ts` — drag threshold, double-click timing, event emission.
 - `ToolManager.test.ts` — tool activation, temporary override, rAF coalescing, modifier forwarding.
 - Per-tool tests: `hand/Hand.test.ts`, `shape/Shape.test.ts`, `Pen.test.ts`, `Select.test.ts`, `Text.test.ts`.

--- a/crates/shift-backends/docs/DOCS.md
+++ b/crates/shift-backends/docs/DOCS.md
@@ -1,6 +1,6 @@
 # shift-backends
 
-<!-- reviewed: 2026-08-19 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Font format backends that convert between on-disk font files and the `Font` IR used throughout the editor.
 
@@ -32,7 +32,7 @@ Font format backends that convert between on-disk font files and the `Font` IR u
 
 **Architecture Invariant:** Compiled-font directories enumerate `maxp` glyph IDs, not only `cmap` mappings. Unencoded glyphs receive their `post`/CFF name or a synthesized `gidN` name. `GlyphIndex` is the dense backend-local GID and never crosses the native session boundary; the bridge maps it to an eager stable session `GlyphId`. WHY: `cmap` is character lookup, not the complete glyph directory.
 
-**Architecture Invariant:** TrueType quadratic segments remain one `OffCurve` control plus one `QCurve` endpoint in the authored layer. Closing qcurve endpoints transfer their type to the wrapped start point. CFF cubic segments remain cubic. The bridge may project a qcurve endpoint as on-curve because clients infer the quadratic from its single control; canonical storage and source export retain the distinction. WHY: lifting every TrueType quadratic to cubic adds a point and derived coordinates to every segment, inflating canonical documents without adding information.
+**Architecture Invariant:** TrueType quadratic segments remain one `OffCurve` control plus one `QCurve` endpoint in the authored layer. Closing qcurve endpoints transfer their type to the wrapped start point. CFF cubic segments remain cubic. The bridge, canonical storage, and source export preserve the qcurve endpoint type; clients treat it as an on-curve anchor without erasing its quadratic identity. WHY: lifting every TrueType quadratic to cubic adds a point and derived coordinates to every segment, inflating canonical documents without adding information.
 
 **Architecture Invariant:** Designspace source locations are complete design-space locations. An omitted source dimension resolves to that axis's mapped default; default-source selection compares against that complete location and never substitutes the first source. A `layer` attribute only selects outline storage. Selected-glyph acquisition compiles source layers into a fallback, compatible normalized deltas, and exact-source exceptions; location evaluation occurs later in TypeScript. WHY: mixing user defaults with design coordinates corrupts interpolation bases.
 

--- a/crates/shift-font/docs/DOCS.md
+++ b/crates/shift-font/docs/DOCS.md
@@ -1,6 +1,6 @@
 # shift-font
 
-<!-- reviewed: 2026-08-21 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 First-class Rust font object model for Shift.
 
@@ -61,7 +61,7 @@ crates/shift-font/src/
 - `GlyphComponents` is the ordered, cycle-pruned component occurrence list for one root glyph. Every `ComponentGlyph` carries its full `ComponentId` ancestry, its zero-based slot within the immediate parent layer, and its Rust-selected anchor attachment. The ancestry identifies the authored occurrence; the parent-local slot correlates numeric transforms across compatible source layers whose corresponding components have different authored IDs.
 - `FontProjection` is a read-only, location-bound view that reuses resolved component layers across one or many glyph requests.
 - `ResolvedGlyph` is derived, flattened geometry plus x advance. An existing blank glyph resolves to an empty contour list; a missing glyph resolves to `None`.
-- `Contour` and `Point` describe outline geometry inside a glyph layer.
+- `Contour` and `Point` describe outline geometry inside a glyph layer. Quadratic path conversion preserves one off-curve control and a `PointType::QCurve` endpoint rather than reducing the endpoint to `OnCurve`.
 
 ## Identity
 

--- a/packages/geo/docs/DOCS.md
+++ b/packages/geo/docs/DOCS.md
@@ -29,6 +29,7 @@ src/
   Rect.ts        -- Rect2D construction and point containment (namespace)
   Curve.ts       -- line/quadratic/cubic bezier primitives with hit-testing
   fitCubic.ts    -- endpoint-tangent-constrained least-squares span fitting
+  fitQuadratic.ts -- one-control least-squares span fitting with exact endpoints
   Polygon.ts     -- polygon area and winding direction
   Mat.ts         -- mutable 2D affine transformation matrix class
 ```
@@ -54,6 +55,8 @@ src/
 **Curve** implements bezier math with a discriminated-union pattern. You construct curves with `Curve.line`, `Curve.quadratic`, or `Curve.cubic`, then pass them to polymorphic functions: `pointAt(curve, t)`, `tangentAt`, `normalAt`, `closestPoint`, `bounds`, `splitAt`, `length`, `sample`. Closest-point queries use a two-phase algorithm: coarse subdivision scan (32 samples) followed by Newton-Raphson refinement (up to 8 iterations at 1e-6 tolerance). `quadraticToCubic` performs lossless degree elevation.
 
 **`Curve.fitCubic(curves)`** approximates a nonempty connected span with one cubic, keeping its endpoints exact and its available endpoint tangent directions fixed. It samples the original curves, normalizes coordinates by sampled path length, solves a bounded two-variable least-squares problem for control lengths, and refines sample parameters with safeguarded Newton steps that preserve traversal order. Singular solves evaluate boundary candidates; zero endpoint derivatives use control-polygon directions; collapsed geometry produces a collapsed cubic. A poor fit keeps the best finite candidate rather than splitting the result or inserting on-curve points. The fit is an approximation, not a guaranteed error-bound simplifier. Its refinement is independent of the closest-point hit-test routine.
+
+**`Curve.fitQuadratic(curves)`** approximates a connected span with one control and exact endpoints. It solves length-weighted least squares at sampled arc-length parameters after normalizing coordinates; unlike cubic fitting, it does not constrain endpoint tangents or refine sample parameters. It preserves a single quadratic exactly and returns a collapsed quadratic for collapsed input. Empty, disconnected, or nonfinite input is rejected. Deletion chooses the output degree from the original span before invoking either fitter, so line-only spans never enter a curve fitter.
 
 **Bounds** provides AABB construction from points, rectangles, or explicit min/max corners, plus composition (`union`, `unionAll`, `includePoint`), queries (`containsPoint`, `overlaps`, `center`, `width`, `height`), and conversion (`toRect`, `expand`).
 

--- a/packages/geo/docs/DOCS.md
+++ b/packages/geo/docs/DOCS.md
@@ -1,6 +1,6 @@
 # @shift/geo
 
-<!-- reviewed: 2026-08-18 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Lightweight 2D geometry library providing pure-functional vector math, bezier curve primitives, bounding boxes, polygon operations, and affine transformation matrices.
 
@@ -28,6 +28,7 @@ src/
   Bounds.ts      -- axis-aligned bounding box (interface + namespace)
   Rect.ts        -- Rect2D construction and point containment (namespace)
   Curve.ts       -- line/quadratic/cubic bezier primitives with hit-testing
+  fitCubic.ts    -- endpoint-tangent-constrained least-squares span fitting
   Polygon.ts     -- polygon area and winding direction
   Mat.ts         -- mutable 2D affine transformation matrix class
 ```
@@ -51,6 +52,8 @@ src/
 **Vec2** is the core building block. It provides construction (`create`, `zero`, `fromAngle`), arithmetic (`add`, `sub`, `scale`, `dot`, `cross`), geometry (`normalize`, `project`, `reflect`, `rotate`, `rotateAround`, `mirror`, `perp`), interpolation (`lerp`, `lerpInt`), and predicates (`equals`, `isParallel`, `isWithin`). Every function takes and returns plain `{ x, y }` objects.
 
 **Curve** implements bezier math with a discriminated-union pattern. You construct curves with `Curve.line`, `Curve.quadratic`, or `Curve.cubic`, then pass them to polymorphic functions: `pointAt(curve, t)`, `tangentAt`, `normalAt`, `closestPoint`, `bounds`, `splitAt`, `length`, `sample`. Closest-point queries use a two-phase algorithm: coarse subdivision scan (32 samples) followed by Newton-Raphson refinement (up to 8 iterations at 1e-6 tolerance). `quadraticToCubic` performs lossless degree elevation.
+
+**`Curve.fitCubic(curves)`** approximates a nonempty connected span with one cubic, keeping its endpoints exact and its available endpoint tangent directions fixed. It samples the original curves, normalizes coordinates by sampled path length, solves a bounded two-variable least-squares problem for control lengths, and refines sample parameters with safeguarded Newton steps that preserve traversal order. Singular solves evaluate boundary candidates; zero endpoint derivatives use control-polygon directions; collapsed geometry produces a collapsed cubic. A poor fit keeps the best finite candidate rather than splitting the result or inserting on-curve points. The fit is an approximation, not a guaranteed error-bound simplifier. Its refinement is independent of the closest-point hit-test routine.
 
 **Bounds** provides AABB construction from points, rectangles, or explicit min/max corners, plus composition (`union`, `unionAll`, `includePoint`), queries (`containsPoint`, `overlaps`, `center`, `width`, `height`), and conversion (`toRect`, `expand`).
 
@@ -99,6 +102,7 @@ Do not chain `.translate(cx, cy)…translate(-cx, -cy)` around rotate/scale: `Ma
 - `Mat` mutates in place. If you need the original matrix after chaining, call `.clone()` first.
 - `Vec2.normalize` returns a zero vector (not NaN) when the input has zero length. Same for `setLen` and `clampLen`.
 - `Curve.closestPoint` clamps `t` to `[0, 1]` -- it finds the closest point on the segment, not the unbounded curve.
+- `Curve.fitCubic` preserves source loops when possible; coincident endpoints alone do not mean the span is collapsed. It rejects empty, disconnected, or nonfinite input. Handle lengths are constrained to at most twice the sampled source length, preventing an ill-conditioned solve from generating unbounded controls.
 - `Polygon.isClockwise` returns `true` for degenerate polygons (fewer than 3 points).
 - `Bounds.fromPoints` returns `null` for empty arrays, not a zero-size bounds.
 - `Mat.invert()` throws if the matrix is singular (determinant is zero).

--- a/packages/glyph-state/docs/DOCS.md
+++ b/packages/glyph-state/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Glyph State
 
-<!-- reviewed: 2026-08-22 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Pure readers and geometry helpers for `GlyphStructure + Float64Array` glyph state.
 
@@ -9,6 +9,7 @@ Pure readers and geometry helpers for `GlyphStructure + Float64Array` glyph stat
 - **Architecture Invariant:** This package has no editor state, signals, command history, bridge calls, source/session selection, DOM APIs, or mutation ownership. It only interprets already-provided glyph state. Its dependency surface is exactly `@shift/types` + `@shift/geo` — enforced by `scripts/check-invariants.py` (`glyph-state-deps`).
 - **Architecture Invariant:** `GlyphGeometry` is a lazy reader over `GlyphStructure + values`. The renderer may cache an instance per reactive state update; rendering paths should not rebuild it inside inner draw loops.
 - **Architecture Invariant:** The flat values layout matches `shift-wire`: xAdvance, contour point positions, anchor positions, then component transforms. Any layout change in Rust must update `GlyphGeometry`, `Contour`, `Anchor`, and `Component` together.
+- **Architecture Invariant:** On-curve predicates accept both `onCurve` and `qCurve`. Point factories preserve the requested endpoint type and smooth flag; only off-curve controls force smoothness off.
 - **Architecture Invariant:** Segment parsing is structural. Two on-curve points produce a line; onCurve/offCurve/onCurve produces a quad; onCurve/offCurve/offCurve/onCurve produces a cubic. Runs starting with an off-curve point are skipped only in open contours — closed contours wrap and consume leading off-curves as controls of the final wrapped segment — and runs of three or more off-curves after an on-curve point are emitted as mis-typed cubics rather than dropped (see Gotchas).
 - **Architecture Invariant:** `bounds` always means tight drawable curve bounds, and sidebearings derive only from those bounds plus advance width. Raw control-point extents are point bounds and must be exposed as `pointBounds` if a consumer needs them; `selectionBounds` may intentionally combine complete curve segments with individually selected points.
 

--- a/packages/types/docs/DOCS.md
+++ b/packages/types/docs/DOCS.md
@@ -1,6 +1,6 @@
 # @shift/types
 
-<!-- reviewed: 2026-08-19 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Shared DTO TypeScript types for Shift. This package owns branded IDs and bridge DTOs generated from `shift-bridge`.
 
@@ -28,7 +28,7 @@ packages/types/src/
 
 Import from `@shift/types`.
 
-- `BridgeApi` -- type-only native bridge API surface.
+- `BridgeApi` -- type-only native bridge API surface, including canonical document open/save/discard and recoverable workspace resume operations.
 - `FontMetadata` / `FontMetrics` -- independent font-level DTOs; metadata mutation replaces the complete `FontMetadata` snapshot without changing metrics.
 - `GlyphRecord` -- committed glyph list record: stable id, name, unicodes, component base glyph IDs.
 - `DocumentIdentity` -- canonical `DocumentId` and canonical path used by the desktop to deduplicate native document sessions before Open.
@@ -43,7 +43,7 @@ Import from `@shift/types`.
 - `Axis` / `AxisMapping` / `NamedInstance` -- generated variation authoring DTOs, keyed by branded entity IDs and expressed in Shift coordinate spaces.
 - `SourceMetricsInterpolationSnapshot` -- derived metric schema, reusable interpolation basis, and ordered source values; it is workspace transport state, not an authored source or named instance.
 - `LayerReplaced` -- one replaced glyph layer in an applied change.
-- `PointType` -- bridge point type union.
+- `PointType` -- bridge point type union: `"onCurve" | "offCurve" | "qCurve"`. Quadratic endpoints remain distinct across transport even though anchor predicates accept both on-curve variants.
 
 ## How it works
 

--- a/packages/ui/docs/DOCS.md
+++ b/packages/ui/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Shared UI (`@shift/ui`)
 
-<!-- reviewed: 2026-08-29 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Shared UI component library for Shift, wrapping Base UI primitives with Tailwind styling and Shift design tokens.
 

--- a/packages/validation/docs/DOCS.md
+++ b/packages/validation/docs/DOCS.md
@@ -1,13 +1,13 @@
 # Validation
 
-<!-- reviewed: 2026-08-18 review-every: 90d -->
+<!-- reviewed: 2026-09-05 review-every: 90d -->
 
 Point sequence and clipboard payload validation for the Shift font editor.
 
 ## Architecture Invariants
 
 - **Architecture Invariant:** Validators never throw. Detailed validators (`sequence`, `canFormSegments`, `hasAnchor`) return a `ValidationResult` discriminated union -- callers branch on `valid` and read `.errors` (structured `ValidationError[]`) on failure. In practice every use is `ValidationResult<void>`: these are check-only validators, no parsed payload is returned. The `Validate` predicates/shortcuts and both `ValidateClipboard` validators return plain `boolean`.
-- **Architecture Invariant:** Point sequences must start and end with `onCurve` points. At most 2 consecutive `offCurve` points are allowed (cubic bezier). 3+ consecutive off-curve points are always invalid.
+- **Architecture Invariant:** Point sequences must start and end with on-curve anchors (`onCurve` or `qCurve`). At most 2 consecutive `offCurve` points are allowed (cubic bezier). 3+ consecutive off-curve points are always invalid.
 - **Architecture Invariant:** `Validate` methods come in pairs: a `ValidationResult`-returning variant for detailed errors (e.g. `canFormSegments`) and a boolean shortcut for hot paths (e.g. `canFormValidSegments`). The boolean variants must enforce identical rules without allocating error objects.
 - **Architecture Invariant:** Clipboard validation checks serialized boundary payloads only. Editor/runtime glyph state validation belongs with the source-aware glyph model, not snapshot-era DTOs.
 
@@ -34,7 +34,7 @@ validation/src/
 
 ### Point sequence validation
 
-`Validate` enforces the rules that make a sequence of `PointLike` objects drawable as bezier curve segments. A valid sequence starts and ends with `onCurve` points, with at most 2 consecutive `offCurve` points between anchors (forming line, quadratic, or cubic segments).
+`Validate` enforces the rules that make a sequence of `PointLike` objects drawable as bezier curve segments. A valid sequence starts and ends with on-curve anchors (`onCurve` or `qCurve`), with at most 2 consecutive `offCurve` points between anchors (forming line, quadratic, or cubic segments).
 
 `Validate.sequence` checks structural validity (bookend on-curve, off-curve run length). `Validate.canFormSegments` additionally walks the sequence to verify every off-curve run is bounded by on-curve anchors -- i.e., the points can actually be decomposed into drawable segments.
 
@@ -54,18 +54,18 @@ Boolean shortcuts (`isValidSequence`, `canFormValidSegments`, `hasValidAnchor`) 
 
 ## Gotchas
 
-- `Validate.sequence` accepts a single `onCurve` point as valid, but `Validate.canFormSegments` requires at least 2 points. Use the right one depending on whether you need drawable segments or just a well-formed sequence.
+- `Validate.sequence` accepts a single `onCurve` or `qCurve` point as valid, but `Validate.canFormSegments` requires at least 2 points. Use the right one depending on whether you need drawable segments or just a well-formed sequence.
 - `ValidateClipboard.isClipboardPayload` hardcodes the format string `"shift/glyph-data"`. If the clipboard format changes, this must be updated in sync.
 - The `PointLike` interface only requires `pointType` -- validators do not check coordinates or IDs. Use clipboard validators at serialization boundaries when full structural validation is needed.
 
 ## Verification
 
 ```bash
-# Run all validation tests
-cd packages/validation && npx vitest run
+# Run validation tests through the root Turbo graph
+pnpm test --filter=@shift/validation
 
 # Type check
-cd packages/validation && npx tsc --noEmit
+pnpm --filter @shift/validation typecheck
 ```
 
 ## Related
@@ -73,4 +73,4 @@ cd packages/validation && npx tsc --noEmit
 - `ClipboardSelection` -- uses `Validate.hasValidAnchor` for copy eligibility and `Validate.isOnCurve`/`isOffCurve` for selection expansion
 - `Clipboard` -- uses `ValidateClipboard.isShiftContent` for paste parsing (imports nothing else from this package)
 - `Segment` (in `@shift/glyph-state`) -- segment decomposition uses glyph-state's own `Point.isOnCurve`/`Point.isOffCurve`, not this package; other `Validate` predicate callers are `ToggleSmooth`, `FontStore`, and `ControlLines`
-- `PointType` from `@shift/types` -- the underlying union (`"onCurve" | "offCurve"`) that `PointLike` wraps
+- `PointType` from `@shift/types` -- the underlying union (`"onCurve" | "offCurve" | "qCurve"`) that `PointLike` wraps


### PR DESCRIPTION
## Summary

- Document tangent-preserving cubic fitting, fitted/gap outline deletion, selection normalization, identity preservation, and real-editor/Electron verification.
- Correct stale quadratic endpoint, rendering, tool completion, preload recovery, and window-chrome descriptions; use root test commands for native-dependent desktop checks.
- Audit source changes since each affected module's review date before refreshing review attestations, including the graphics contract changed by #362 after this branch was created.
- Documentation only.

## Issue

Refs #352

## Testing

Passed inside the Nix development shell:

- `python3 scripts/context-drift-check.py` — all 20 module documents clean, with no errors or freshness warnings.
- `pnpm format:check`
- `git diff --check`
- Applicable commit hooks: whitespace, EOF, large-file/conflict checks, and formatting.
- Manual source-to-document comparison of changes since each affected review attestation.

Runtime tests and Electron E2E were not rerun for this documentation-only change; feature validation is recorded in #353 and #354. This PR changes no runtime code, configuration, or visual snapshots.
