### PR TITLE
fix(editor): preserve constrained scaling on mouse release

### DIFF
--- a/apps/desktop/e2e/editor.spec.ts
+++ b/apps/desktop/e2e/editor.spec.ts
@@ -165,6 +165,58 @@ test.describe("Editor view", () => {
     await expect.poll(() => selectionBounds(page)).toMatchObject({ x: targetX, y: targetY });
   });
 
+  for (const releaseShiftFirst of [true, false]) {
+    test(`keeps constrained drag geometry when Shift is released ${releaseShiftFirst ? "before" : "after"} mouseup`, async ({
+      page,
+    }) => {
+      await page.keyboard.press("ControlOrMeta+a");
+      const initialBounds = await selectionBounds(page);
+      const canvas = page.locator("#interactive-canvas");
+      const canvasBounds = await canvas.boundingBox();
+      if (!canvasBounds) throw new Error("Expected interactive canvas bounds");
+      const { down, end } = await page.evaluate(() => {
+        const editor = window.shift!.editor;
+        const bounds = editor.selectionBounds();
+        if (!bounds) throw new Error("Expected selection bounds");
+
+        return {
+          down: editor.projectSceneToScreen({ x: bounds.right, y: bounds.bottom }),
+          end: editor.projectSceneToScreen({
+            x: bounds.right + bounds.width * 0.15,
+            y: bounds.bottom + bounds.height * 0.03,
+          }),
+        };
+      });
+
+      await page.mouse.move(canvasBounds.x + down.x, canvasBounds.y + down.y);
+      await page.keyboard.down("Shift");
+      await page.mouse.down();
+      try {
+        await page.mouse.move(canvasBounds.x + end.x, canvasBounds.y + end.y, { steps: 3 });
+        await page.evaluate(() => window.shift!.editor.toolManager.flushPointerMoves());
+        await expect
+          .poll(() => page.evaluate(() => window.shift!.editor.toolIf("select")?.state.type))
+          .toBe("resizing");
+        const preview = await selectionBounds(page);
+        expect(preview.width).toBeGreaterThan(initialBounds.width);
+        expect(preview.width / initialBounds.width).toBeCloseTo(
+          preview.height / initialBounds.height,
+        );
+
+        if (releaseShiftFirst) await page.keyboard.up("Shift");
+        await page.mouse.up();
+        if (!releaseShiftFirst) await page.keyboard.up("Shift");
+        await page.evaluate(async () => window.shift!.font.editCoordinator.settled());
+
+        expect(await selectionBounds(page)).toEqual(preview);
+        await expect(page.getByTestId("editor-shell")).toHaveAttribute("data-gesture", "idle");
+      } finally {
+        await page.mouse.up();
+        await page.keyboard.up("Shift");
+      }
+    });
+  }
+
   test("applies scaling around the selected scale anchor", async ({ page }) => {
     await page.keyboard.press("Meta+a");
     const properties = glyphProperties(page);

--- a/apps/desktop/src/renderer/src/lib/tools/core/GestureDetector.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/GestureDetector.test.ts
@@ -171,6 +171,60 @@ describe("GestureDetector", () => {
       });
     });
 
+    it.each([true, false])(
+      "retains the last drag modifiers when release keys change (held=%s)",
+      (held) => {
+        const modifiers = { shiftKey: held, altKey: held, metaKey: held, ctrlKey: held };
+        detector.pointerDown(c(100, 100), NO_MODIFIERS);
+        detector.pointerMove(c(110, 100), modifiers);
+        const events = detector.pointerUp(c(120, 110), {
+          shiftKey: !held,
+          altKey: !held,
+          metaKey: !held,
+          ctrlKey: !held,
+        });
+
+        expect(events).toEqual([
+          expect.objectContaining({
+            type: "drag",
+            coords: c(120, 110),
+            ...modifiers,
+            accelKey: held,
+          }),
+          expect.objectContaining({
+            type: "dragEnd",
+            coords: c(120, 110),
+            ...modifiers,
+            accelKey: held,
+          }),
+        ]);
+      },
+    );
+
+    it("adopts modifier changes on the next drag movement", () => {
+      detector.pointerDown(c(100, 100), NO_MODIFIERS);
+      detector.pointerMove(c(110, 100), { ...NO_MODIFIERS, shiftKey: true });
+      detector.pointerMove(c(120, 100), NO_MODIFIERS);
+      const events = detector.pointerUp(c(130, 100), { ...NO_MODIFIERS, shiftKey: true });
+
+      expect(events).toEqual([
+        expect.objectContaining({ type: "drag", coords: c(130, 100), shiftKey: false }),
+        expect.objectContaining({ type: "dragEnd", coords: c(130, 100), shiftKey: false }),
+      ]);
+    });
+
+    it("uses release modifiers for a click after a completed constrained drag", () => {
+      detector.pointerDown(c(100, 100), NO_MODIFIERS);
+      detector.pointerMove(c(110, 100), { ...NO_MODIFIERS, shiftKey: true });
+      detector.pointerUp(c(110, 100), NO_MODIFIERS);
+      detector.pointerDown(c(200, 200), { ...NO_MODIFIERS, shiftKey: true });
+      const events = detector.pointerUp(c(200, 200), NO_MODIFIERS);
+
+      expect(events).toEqual([
+        expect.objectContaining({ type: "click", ...NORMALIZED_NO_MODIFIERS }),
+      ]);
+    });
+
     it("isDragging returns true during drag", () => {
       expect(detector.isDragging).toBe(false);
 
@@ -196,6 +250,20 @@ describe("GestureDetector", () => {
       const events = detector.pointerMove(c(120, 100), NO_MODIFIERS);
       expect(events).toHaveLength(1);
       expect(expectAt(events, 0).type).toBe("pointerMove");
+    });
+
+    it("does not retain canceled drag modifiers in the next gesture", () => {
+      detector.pointerDown(c(100, 100), NO_MODIFIERS);
+      detector.pointerMove(c(110, 100), { ...NO_MODIFIERS, shiftKey: true });
+      detector.reset();
+      detector.pointerDown(c(200, 200), NO_MODIFIERS);
+      detector.pointerMove(c(210, 200), NO_MODIFIERS);
+      const events = detector.pointerUp(c(220, 200), NO_MODIFIERS);
+
+      expect(events).toEqual([
+        expect.objectContaining({ type: "drag", ...NORMALIZED_NO_MODIFIERS }),
+        expect.objectContaining({ type: "dragEnd", ...NORMALIZED_NO_MODIFIERS }),
+      ]);
     });
 
     it("resets double-click tracking", () => {

--- a/apps/desktop/src/renderer/src/lib/tools/core/GestureDetector.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/GestureDetector.ts
@@ -177,6 +177,7 @@ const DEFAULT_CONFIG: Required<GestureDetectorConfig> = {
 export class GestureDetector {
   private downCoords: Coordinates | null = null;
   private downModifiers: ModifierKeys | null = null;
+  private lastDragModifiers: ModifierKeys | null = null;
   private dragging = false;
   private lastClickTime = 0;
   private lastClickPoint: Point2D | null = null;
@@ -199,6 +200,7 @@ export class GestureDetector {
   pointerDown(coords: Coordinates, modifiers: Modifiers): void {
     this.downCoords = coords;
     this.downModifiers = normalizeModifiers(modifiers);
+    this.lastDragModifiers = null;
     this.dragging = false;
   }
 
@@ -223,6 +225,7 @@ export class GestureDetector {
 
     if (!this.dragging && distance > this.dragThreshold) {
       this.dragging = true;
+      this.lastDragModifiers = modifierKeys;
       return [
         {
           type: "dragStart",
@@ -242,6 +245,7 @@ export class GestureDetector {
     }
 
     if (this.dragging) {
+      this.lastDragModifiers = modifierKeys;
       return [
         {
           type: "drag",
@@ -257,13 +261,22 @@ export class GestureDetector {
   }
 
   /**
-   * Process a pointer release. Returns the final `drag` sample before `dragEnd`
-   * if dragging, `doubleClick` within timing/distance thresholds, or `click`.
+   * Completes a gesture at the release position without changing its drag constraints.
+   *
+   * @remarks
+   * The final `drag` and `dragEnd` retain the latest drag sample's modifiers.
+   * Modifier changes affect dragging only when another pointer move is processed;
+   * releasing a key just before the pointer does not reshape the final preview.
+   * Completion clears the retained pointer and drag-modifier state.
+   *
+   * @param coords - Final pointer position, including movement since the last drag sample.
+   * @param modifiers - Release-time modifiers used for clicks and double-clicks only.
+   * @returns The final `drag` followed by `dragEnd`, a click event, or no events if unpressed.
    */
   pointerUp(coords: Coordinates, modifiers: Modifiers): GestureEvent[] {
     if (!this.downCoords || !this.downModifiers) return [];
 
-    const modifierKeys = normalizeModifiers(modifiers);
+    const modifierKeys = this.lastDragModifiers ?? normalizeModifiers(modifiers);
     const events: GestureEvent[] = [];
     const delta = pointerDelta(coords, this.downCoords);
 
@@ -326,6 +339,7 @@ export class GestureDetector {
   private resetPointerState(): void {
     this.downCoords = null;
     this.downModifiers = null;
+    this.lastDragModifiers = null;
     this.dragging = false;
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -88,7 +88,7 @@ User pointer/key
 
 - Crossing the screen-space threshold emits `dragStart` at the pointer-down origin, immediately followed by the first `drag` sample.
 - Every `drag.delta` is cumulative from pointer-down; the threshold classifies the gesture but does not become a new origin.
-- Pointer-up drains queued movement and emits the final `drag` sample before `dragEnd`.
+- Pointer-up drains queued movement and emits the final `drag` sample before `dragEnd`. Both release events use the final pointer position with the latest drag sample's modifiers, so releasing Shift just before mouseup does not change the preview's constraints. Modifier changes take effect on the next processed drag movement; clicks and double-clicks still use release-time modifiers. `GestureDetector.lastDragModifiers` is empty before dragging, follows each emitted drag movement, and clears on completion, cancellation, or a new pointer-down.
 - Behaviors initialize on `dragStart`, register rollback with `ctx.onCancel()`, preview from `drag`, and commit on `dragEnd` before dismissing rollback.
 - `BaseTool` runs any rollback left active at `dragEnd`, `dragCancel`, tool disposal, or after a handler throws.
 

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
@@ -376,6 +376,94 @@ describe("Select tool", () => {
       expect(secondAfter.y).toBeCloseTo(250);
     });
 
+    describe("constrained resize release", () => {
+      beforeEach(async () => {
+        const ids = await editor.drawOpenContour([
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+        ]);
+        editor.selection.select(ids);
+        editor.selectTool("select");
+      });
+
+      it.each([true, false])(
+        "commits the visible preview with Shift held=%s at release",
+        async (shiftKey) => {
+          const layer = editor.requireGlyphLayer();
+          const down = editor.projectSceneToScreen({ x: 200, y: 200 });
+          const end = editor.projectSceneToScreen({ x: 250, y: 225 });
+          editor.pointerDown(down.x, down.y, { shiftKey: true });
+          editor.pointerMove(end.x, end.y, { shiftKey: true });
+          expect(editor.toolManager.activeTool?.state.type).toBe("resizing");
+
+          const preview = layer.contours[0]!.points.map(({ x, y }) => ({ x, y }));
+          expect(preview).toEqual([
+            { x: 100, y: 100 },
+            { x: 250, y: 250 },
+          ]);
+          editor.pointerUp(end.x, end.y, { shiftKey });
+          await editor.settle();
+
+          expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual(preview);
+        },
+      );
+
+      it("uses the release position with the last preview constraints and preserves undo", async () => {
+        const layer = editor.requireGlyphLayer();
+        const down = editor.projectSceneToScreen({ x: 200, y: 200 });
+        const move = editor.projectSceneToScreen({ x: 250, y: 225 });
+        const up = editor.projectSceneToScreen({ x: 275, y: 230 });
+        editor.pointerDown(down.x, down.y).pointerMove(move.x, move.y, { shiftKey: true });
+        editor.pointerUp(up.x, up.y);
+        await editor.settle();
+        expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual([
+          { x: 100, y: 100 },
+          { x: 275, y: 275 },
+        ]);
+
+        await editor.undo();
+        expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual([
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+        ]);
+        await editor.redo();
+        expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual([
+          { x: 100, y: 100 },
+          { x: 275, y: 275 },
+        ]);
+      });
+
+      it("removes the constraint when dragging continues without Shift", async () => {
+        const layer = editor.requireGlyphLayer();
+        const down = editor.projectSceneToScreen({ x: 200, y: 200 });
+        const move = editor.projectSceneToScreen({ x: 250, y: 225 });
+        const end = editor.projectSceneToScreen({ x: 275, y: 230 });
+        editor.pointerDown(down.x, down.y).pointerMove(move.x, move.y, { shiftKey: true });
+        editor.pointerMove(end.x, end.y).pointerUp(end.x, end.y, { shiftKey: true });
+        await editor.settle();
+
+        expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual([
+          { x: 100, y: 100 },
+          { x: 275, y: 230 },
+        ]);
+      });
+
+      it("uses the modifiers from a queued movement drained at mouseup", async () => {
+        const layer = editor.requireGlyphLayer();
+        const down = editor.projectSceneToScreen({ x: 200, y: 200 });
+        const move = editor.projectSceneToScreen({ x: 250, y: 225 });
+        editor.pointerDown(down.x, down.y);
+        editor.toolManager.handlePointerMove(move, { shiftKey: true, altKey: false });
+        editor.pointerUp(move.x, move.y);
+        await editor.settle();
+
+        expect(layer.contours[0]!.points.map(({ x, y }) => ({ x, y }))).toEqual([
+          { x: 100, y: 100 },
+          { x: 250, y: 250 },
+        ]);
+      });
+    });
+
     it("rotates the current selection from the pointer-down bounding-box zone", async () => {
       editor.selectTool("pen");
       await editor.clickGlyphLocal(100, 100);


### PR DESCRIPTION
## Summary

- Prevent constrained scaling from jumping when Shift is released just before mouseup. Final drag events retain the latest drag sample's modifiers while still using the release position.
- Apply modifier changes on continued drag movement; preserve release-time modifiers for clicks and clear retained drag modifiers between gestures. This rule lives at the shared gesture boundary, not in a resize-only workaround.
- Add 10 unit/integration cases and two real Electron release-order cases covering final coordinates, queued movement, modifier changes, cancellation, and undo/redo. No screenshot baselines or styling changed.

## Issue

Closes #358

## Testing

Passed on macOS:

- `pnpm test` — all package suites passed; desktop: 84 files, 810 tests.
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `pnpm test:e2e:visual e2e/editor.spec.ts --grep 'constrained drag geometry|applies scaling'` — 3 passed, including actual keyboard release before and after mouseup.
- `pnpm test:e2e:visual e2e/tools.spec.ts --grep 'Canvas pointer lifecycle'` — 3 passed, covering pointer capture, early capture loss, and DOM cancellation.
- `git diff --check`

Other results:

- Before the fix, `pnpm test:desktop src/renderer/src/lib/tools/select/Select.test.ts -t 'constrained resize release'` reproduced the geometry jump for Shift released before mouseup; that regression now passes in the full suite.
- `python3 scripts/context-drift-check.py` exits 1 with 12 documentation-freshness warnings.
- Full visual snapshot, GPU, and Windows/Linux suites were not run. Validation focused on gesture behavior and existing pointer-lifecycle coverage; rendering and shared E2E fixtures are unchanged.
