### PR TITLE
feat(editor): refresh canvas cursors and show bend feedback

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -426,7 +426,7 @@ These are allowed to jump around when energy is high, but they should not silent
 
 - [ ] Ruler tool (measure distance/angle between points)
 - [ ] Knife tool (cut contours at intersection)
-- [ ] Bend curves with mouse (drag segment to reshape)
+- [x] Bend curves with mouse (drag segment to reshape)
 - [ ] Shape tool: rectangles with corner radius
 - [ ] Shape tool: circles and ellipses
 - [ ] Shape tool: regular polygons (triangle, pentagon, etc.)

--- a/apps/desktop/e2e/editor.spec.ts
+++ b/apps/desktop/e2e/editor.spec.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { workspaceTest as test, expect, navigateToEditor } from "./fixtures/electronApp";
-import { glyphProperties } from "./fixtures/appLocators";
+import { glyphProperties, variationControls } from "./fixtures/appLocators";
 import { CanvasUtil } from "./fixtures/CanvasUtil";
 
 async function selectionBounds(page: Page) {
@@ -56,6 +56,62 @@ test.describe("Editor view", () => {
     await rightDivider.dispatchEvent("dblclick");
     await expect.poll(() => elementWidth(rightSidebar)).toBeCloseTo(defaultWidth, 0);
     await expect.poll(() => elementWidth(leftSidebar)).toBeCloseTo(defaultWidth, 0);
+  });
+
+  test("keeps custom cursors on the canvas while hovering and bending across sidebars", async ({
+    page,
+  }) => {
+    const canvas = page.locator("#interactive-canvas");
+    const canvasBounds = await canvas.boundingBox();
+    if (!canvasBounds) throw new Error("Expected interactive canvas bounds");
+    const down = await page.evaluate(() => {
+      const editor = window.shift!.editor;
+      const node = editor.scene.nodesOfKind("glyph")[0];
+      if (!node) throw new Error("Expected glyph node");
+      const layer = editor.glyphForId(node.glyphId)?.layerForSource(node.sourceId);
+      const segment = layer?.contours[0]?.segments()[0];
+      if (!segment) throw new Error("Expected segment");
+      const point = segment.pointAt(0.5);
+
+      return editor.projectSceneToScreen({
+        x: point.x + node.position.x,
+        y: point.y + node.position.y,
+      });
+    });
+
+    await canvas.hover({ position: down });
+    await expect(canvas).toHaveCSS("cursor", /cursor@32\.svg/);
+    await canvas.click({ position: down, modifiers: ["Alt"] });
+    await page.evaluate(async () => window.shift!.font.editCoordinator.settled());
+    await page.keyboard.down("Meta");
+    try {
+      await expect(canvas).toHaveCSS("cursor", /cursor@32-bend\.svg/);
+      for (const sidebar of [variationControls(page), glyphProperties(page)]) {
+        await sidebar.hover({ position: { x: 10, y: 10 } });
+        await expect(sidebar).not.toHaveCSS("cursor", /cursors\//);
+      }
+
+      await canvas.hover({ position: down });
+      await page.mouse.down();
+      for (const sidebar of [variationControls(page), glyphProperties(page)]) {
+        await expect(sidebar).not.toHaveCSS("cursor", /cursors\//);
+        const bounds = await sidebar.boundingBox();
+        if (!bounds) throw new Error("Expected sidebar bounds");
+        await page.mouse.move(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2, {
+          steps: 3,
+        });
+        await expect
+          .poll(() => page.evaluate(() => window.shift!.editor.toolIf("select")?.state.type))
+          .toBe("bending");
+        await expect(canvas).toHaveCSS("cursor", /cursor@32-bend\.svg/);
+        await expect(sidebar).not.toHaveCSS("cursor", /cursors\//);
+      }
+    } finally {
+      await page.keyboard.press("Escape");
+      await page.mouse.up();
+      await page.keyboard.up("Meta");
+    }
+    await expect(canvas).toHaveCSS("cursor", /cursor@32\.svg/);
   });
 
   test("remains interactive after a renderer reload", async ({ page }) => {

--- a/apps/desktop/src/renderer/public/cursors/cursor@32-bend.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@32-bend.svg
@@ -1,0 +1,64 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1782_3613)">
+<path d="M5.32856 3.13114C5.19682 2.63568 5.64673 2.18231 6.13841 2.31507L16.8152 5.19787C17.4414 5.36696 17.4772 6.24882 16.8668 6.46886L11.9333 8.24724C11.4539 8.42007 11.0802 8.8059 10.9205 9.29311C10.339 11.0666 10.013 12.0609 9.43148 13.8344C9.22547 14.4627 8.33486 14.4369 8.16491 13.7978L5.32856 3.13114Z" fill="black"/>
+<path d="M4.60416 3.32388C4.32701 2.28161 5.27357 1.30534 6.33365 1.59146L17.0104 4.47427C18.3468 4.8351 18.4196 6.70626 17.1208 7.17447L12.1872 8.95279C11.9267 9.04681 11.7217 9.25787 11.6335 9.52701C11.3427 10.4137 11.1152 11.1056 10.8883 11.7975C10.6615 12.4894 10.4349 13.1814 10.1442 14.068C9.70522 15.4068 7.80173 15.3497 7.44009 13.9909L4.60416 3.32388Z" stroke="white" stroke-width="1.5"/>
+</g>
+<g filter="url(#filter1_d_1782_3613)">
+<mask id="path-3-outside-1_1782_3613" maskUnits="userSpaceOnUse" x="11.1008" y="8.15651" width="15.5563" height="15.5563" fill="black">
+<rect fill="white" x="11.1008" y="8.15651" width="15.5563" height="15.5563"/>
+<path d="M24.7004 12.7809C24.3395 12.42 23.8601 12.1847 23.2896 12.0885C22.7191 11.9922 22.0685 12.0368 21.3752 12.2198C20.6818 12.4028 19.9592 12.7206 19.2486 13.155C18.538 13.5893 17.8534 14.1319 17.2337 14.7515C16.614 15.3712 16.0715 16.0559 15.6371 16.7665C15.2027 17.4771 14.885 18.1997 14.702 18.893C14.519 19.5864 14.4743 20.2369 14.5706 20.8074C14.6669 21.378 14.9022 21.8574 15.2631 22.2183L16.6487 20.8326C16.3938 20.5777 16.2276 20.2391 16.1596 19.8361C16.0916 19.4331 16.1232 18.9736 16.2524 18.4838C16.3817 17.9941 16.6061 17.4837 16.9129 16.9818C17.2198 16.4798 17.603 15.9962 18.0407 15.5585C18.4784 15.1208 18.962 14.7376 19.4639 14.4308C19.9658 14.124 20.4763 13.8995 20.966 13.7702C21.4557 13.641 21.9152 13.6095 22.3182 13.6775C22.7212 13.7455 23.0598 13.9117 23.3148 14.1666L24.7004 12.7809Z"/>
+</mask>
+<path d="M24.7004 12.7809C24.3395 12.42 23.8601 12.1847 23.2896 12.0885C22.7191 11.9922 22.0685 12.0368 21.3752 12.2198C20.6818 12.4028 19.9592 12.7206 19.2486 13.155C18.538 13.5893 17.8534 14.1319 17.2337 14.7515C16.614 15.3712 16.0715 16.0559 15.6371 16.7665C15.2027 17.4771 14.885 18.1997 14.702 18.893C14.519 19.5864 14.4743 20.2369 14.5706 20.8074C14.6669 21.378 14.9022 21.8574 15.2631 22.2183L16.6487 20.8326C16.3938 20.5777 16.2276 20.2391 16.1596 19.8361C16.0916 19.4331 16.1232 18.9736 16.2524 18.4838C16.3817 17.9941 16.6061 17.4837 16.9129 16.9818C17.2198 16.4798 17.603 15.9962 18.0407 15.5585C18.4784 15.1208 18.962 14.7376 19.4639 14.4308C19.9658 14.124 20.4763 13.8995 20.966 13.7702C21.4557 13.641 21.9152 13.6095 22.3182 13.6775C22.7212 13.7455 23.0598 13.9117 23.3148 14.1666L24.7004 12.7809Z" fill="black"/>
+<path d="M24.7004 12.7809C24.3395 12.42 23.8601 12.1847 23.2896 12.0885C22.7191 11.9922 22.0685 12.0368 21.3752 12.2198C20.6818 12.4028 19.9592 12.7206 19.2486 13.155C18.538 13.5893 17.8534 14.1319 17.2337 14.7515C16.614 15.3712 16.0715 16.0559 15.6371 16.7665C15.2027 17.4771 14.885 18.1997 14.702 18.893C14.519 19.5864 14.4743 20.2369 14.5706 20.8074C14.6669 21.378 14.9022 21.8574 15.2631 22.2183L16.6487 20.8326C16.3938 20.5777 16.2276 20.2391 16.1596 19.8361C16.0916 19.4331 16.1232 18.9736 16.2524 18.4838C16.3817 17.9941 16.6061 17.4837 16.9129 16.9818C17.2198 16.4798 17.603 15.9962 18.0407 15.5585C18.4784 15.1208 18.962 14.7376 19.4639 14.4308C19.9658 14.124 20.4763 13.8995 20.966 13.7702C21.4557 13.641 21.9152 13.6095 22.3182 13.6775C22.7212 13.7455 23.0598 13.9117 23.3148 14.1666L24.7004 12.7809Z" stroke="white" stroke-width="2" mask="url(#path-3-outside-1_1782_3613)"/>
+</g>
+<g filter="url(#filter2_d_1782_3613)">
+<circle cx="17.5818" cy="22.8803" r="2.4" fill="black"/>
+<circle cx="17.5818" cy="22.8803" r="1.9" stroke="white"/>
+</g>
+<g filter="url(#filter3_d_1782_3613)">
+<circle cx="25.5782" cy="14.7966" r="2.4" fill="black"/>
+<circle cx="25.5782" cy="14.7966" r="1.9" stroke="white"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_3613" x="3.80457" y="0.789246" width="17.0007" height="17.0025" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3613"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3613" result="shape"/>
+</filter>
+<filter id="filter1_d_1782_3613" x="10.3212" y="11.039" width="18.9934" height="18.9935" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.2"/>
+<feGaussianBlur stdDeviation="1.6"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3613"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3613" result="shape"/>
+</filter>
+<filter id="filter2_d_1782_3613" x="11.9818" y="20.4803" width="11.2" height="11.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.2"/>
+<feGaussianBlur stdDeviation="1.6"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3613"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3613" result="shape"/>
+</filter>
+<filter id="filter3_d_1782_3613" x="19.9782" y="12.3966" width="11.2" height="11.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="3.2"/>
+<feGaussianBlur stdDeviation="1.6"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3613"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3613" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/apps/desktop/src/renderer/public/cursors/cursor@32-copy.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@32-copy.svg
@@ -1,34 +1,36 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_89_1069)">
-<g filter="url(#filter0_d_89_1069)">
-<path d="M17.8488 15.2201C18.003 15.5903 17.8548 16.9926 17.0368 17.3176C16.2189 17.6427 15.1738 17.3176 15.1738 17.3176L13.2775 13.5249L10 16.8024V2L20.04 12.04H16.2993C16.4829 12.392 17.6528 14.7497 17.8488 15.2201Z" fill="black"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M10.8796 4.12355V14.6788L13.5184 12.04L15.7174 16.438C15.7174 16.438 16.3123 16.6278 16.597 16.438C16.8817 16.2482 17.1649 15.8659 17.0368 15.5584C16.4319 14.1067 14.8378 11.1604 14.8378 11.1604H17.9164L10.8796 4.12355Z" fill="white"/>
+<g clip-path="url(#clip0_1778_3255)">
+<g filter="url(#filter0_d_1778_3255)">
+<path d="M10.8666 2.31638C10.5622 1.17139 11.5609 0.0912762 12.7211 0.321259L12.8334 0.347626L22.6205 2.9902C24.1396 3.40035 24.222 5.5255 22.7465 6.05759L18.2241 7.68845C18.076 7.74187 17.9571 7.86218 17.9057 8.01852L16.5405 12.1816C16.0415 13.7033 13.8768 13.6378 13.4662 12.0937L10.8666 2.31638Z" stroke="white" stroke-width="1.99618" shape-rendering="crispEdges"/>
 </g>
-<g filter="url(#filter1_d_89_1069)">
-<path d="M14.553 16.0906C14.7408 16.5412 14.5603 18.2479 13.5648 18.6436C12.5692 19.0392 11.2972 18.6436 11.2972 18.6436L8.98909 14.0273L5 18.0164V0L17.22 12.22H12.6671C12.8905 12.6484 14.3145 15.5181 14.553 16.0906Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M6.07059 2.58464V15.4318L9.28237 12.22L11.9589 17.573C11.9589 17.573 12.6829 17.804 13.0295 17.573C13.376 17.3419 13.7207 16.8766 13.5648 16.5024C12.8285 14.7354 10.8883 11.1494 10.8883 11.1494H14.6353L6.07059 2.58464Z" fill="black"/>
+<path d="M11.2524 2.21384C11.0155 1.32302 11.8253 0.48912 12.7299 0.733368L22.517 3.37595C23.6579 3.68419 23.72 5.28275 22.6108 5.68259L18.0883 7.31247C17.8237 7.40796 17.6152 7.622 17.5258 7.8945L16.1616 12.0576C15.7866 13.2008 14.1617 13.1518 13.853 11.9912L11.2524 2.21384Z" fill="white" stroke="black" stroke-width="1.19771"/>
+<g filter="url(#filter1_d_1778_3255)">
+<path d="M5.33323 3.12949C5.20149 2.63404 5.6514 2.18066 6.14308 2.31342L16.8199 5.19622C17.4461 5.36531 17.4819 6.24717 16.8715 6.46722L11.938 8.24559C11.4585 8.41842 11.0849 8.80425 10.9251 9.29146L9.43614 13.8327C9.23014 14.461 8.33953 14.4353 8.16957 13.7961L5.33323 3.12949Z" fill="black"/>
+<path d="M4.60883 3.32224C4.33168 2.27996 5.27824 1.30369 6.33832 1.58981L17.0151 4.47263C18.3515 4.83346 18.4243 6.70461 17.1254 7.17282L12.1918 8.95114C11.9314 9.04516 11.7264 9.25622 11.6381 9.52536L10.1489 14.0664C9.70989 15.4052 7.8064 15.3481 7.44476 13.9892L4.60883 3.32224Z" stroke="white" stroke-width="1.5"/>
 </g>
 </g>
 <defs>
-<filter id="filter0_d_89_1069" x="7.6" y="0.933333" width="14.84" height="20.2621" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1778_3255" x="7.09796" y="-0.709412" width="20.423" height="20.4253" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="1.33333"/>
-<feGaussianBlur stdDeviation="1.2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1069"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1069" result="shape"/>
+<feOffset dy="2.71481"/>
+<feGaussianBlur stdDeviation="1.35741"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1778_3255"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1778_3255" result="shape"/>
 </filter>
-<filter id="filter1_d_89_1069" x="2.6" y="-1.06667" width="17.02" height="23.6194" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_d_1778_3255" x="3.80923" y="0.787598" width="17.0008" height="17.0025" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="1.33333"/>
-<feGaussianBlur stdDeviation="1.2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1069"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1069" result="shape"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1778_3255"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1778_3255" result="shape"/>
 </filter>
-<clipPath id="clip0_89_1069">
+<clipPath id="clip0_1778_3255">
 <rect width="32" height="32" fill="white"/>
 </clipPath>
 </defs>

--- a/apps/desktop/src/renderer/public/cursors/cursor@32-moving.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@32-moving.svg
@@ -1,36 +1,32 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_89_1074)">
-<g filter="url(#filter0_d_89_1074)">
-<path d="M14.553 16.0906C14.7408 16.5412 14.5603 18.2479 13.5648 18.6436C12.5692 19.0392 11.2972 18.6436 11.2972 18.6436L8.98909 14.0273L5 18.0164V0L17.22 12.22H12.6671C12.8905 12.6484 14.3145 15.5181 14.553 16.0906Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M6.07059 2.58464V15.4318L9.28237 12.22L11.9589 17.573C11.9589 17.573 12.6829 17.804 13.0295 17.573C13.376 17.3419 13.7207 16.8766 13.5648 16.5024C12.8285 14.7354 10.8883 11.1494 10.8883 11.1494H14.6353L6.07059 2.58464Z" fill="black"/>
+<g filter="url(#filter0_d_1778_3277)">
+<path d="M5.33323 3.12949C5.20149 2.63404 5.6514 2.18066 6.14308 2.31342L16.8199 5.19622C17.4461 5.36531 17.4819 6.24717 16.8715 6.46722L11.938 8.24559C11.4585 8.41842 11.0849 8.80425 10.9251 9.29146L9.43614 13.8327C9.23014 14.461 8.33953 14.4353 8.16957 13.7961L5.33323 3.12949Z" fill="black"/>
+<path d="M4.60883 3.32224C4.33168 2.27996 5.27824 1.30369 6.33832 1.58981L17.0151 4.47263C18.3515 4.83346 18.4243 6.70461 17.1254 7.17282L12.1918 8.95114C11.9314 9.04516 11.7264 9.25622 11.6381 9.52536L10.1489 14.0664C9.70989 15.4052 7.8064 15.3481 7.44476 13.9892L4.60883 3.32224Z" stroke="white" stroke-width="1.5"/>
 </g>
-<g filter="url(#filter1_d_89_1074)">
-<path d="M21 17L14 24L18.5675 28.5675L21 31L28 24L21 17ZM19.25 26.625H18.375V25.75H19.25V26.625ZM19.25 22.25H18.375V21.375H19.25V22.25ZM23.625 26.625H22.75V25.75H23.625V26.625ZM22.75 21.375H23.625V22.25H22.75V21.375Z" fill="white"/>
-<path d="M26.7313 23.9825L24.4913 21.5238V23.125H20.9913H17.4825V21.5238L15.2338 23.9825L17.4825 26.4413V24.8575H20.9913H24.4913V26.4413L26.7313 23.9825Z" fill="black"/>
-<path d="M21.8487 23.9913H21.8575V20.4913H23.4412L20.9912 18.2425L18.5325 20.4913H20.1162V23.9913V27.4913H18.5237L20.9737 29.74L23.4325 27.4913H21.8487V23.9913Z" fill="black"/>
-</g>
+<g filter="url(#filter1_d_1778_3277)">
+<path d="M21.7071 9.70711C21.3166 9.31658 20.6834 9.31658 20.2929 9.70711L14.7071 15.2929C14.3166 15.6834 14.3166 16.3166 14.7071 16.7071L18.5675 20.5675L20.2929 22.2929C20.6834 22.6834 21.3166 22.6834 21.7071 22.2929L27.2929 16.7071C27.6834 16.3166 27.6834 15.6834 27.2929 15.2929L21.7071 9.70711ZM19.25 18.625H18.375V17.75H19.25V18.625ZM19.25 14.25H18.375V13.375H19.25V14.25ZM23.625 18.625H22.75V17.75H23.625V18.625ZM22.75 13.375H23.625V14.25H22.75V13.375Z" fill="white"/>
+<path d="M26.7313 15.9825L24.4913 13.5238V15.125H20.9913H17.4826V13.5238L15.2338 15.9825L17.4826 18.4413V16.8575H20.9913H24.4913V18.4413L26.7313 15.9825Z" fill="black"/>
+<path d="M21.8487 15.9913H21.8575V12.4913H23.4412L20.9912 10.2425L18.5325 12.4913H20.1162V15.9913V19.4913H18.5237L20.9737 21.74L23.4325 19.4913H21.8487V15.9913Z" fill="black"/>
 </g>
 <defs>
-<filter id="filter0_d_89_1074" x="2.6" y="-1.06667" width="17.02" height="23.6194" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1778_3277" x="3.8092" y="0.787598" width="17.0008" height="17.0025" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="1.33333"/>
-<feGaussianBlur stdDeviation="1.2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1074"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1074" result="shape"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1778_3277"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1778_3277" result="shape"/>
 </filter>
-<filter id="filter1_d_89_1074" x="12.2" y="16.2" width="17.6" height="17.6" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_d_1778_3277" x="12.6142" y="8.61422" width="16.7716" height="16.7716" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
 <feOffset dy="1"/>
 <feGaussianBlur stdDeviation="0.9"/>
 <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1074"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1074" result="shape"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1778_3277"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1778_3277" result="shape"/>
 </filter>
-<clipPath id="clip0_89_1074">
-<rect width="32" height="32" fill="white"/>
-</clipPath>
 </defs>
 </svg>

--- a/apps/desktop/src/renderer/public/cursors/cursor@32.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@32.svg
@@ -1,22 +1,18 @@
 <svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_89_1069)">
-<g filter="url(#filter0_d_89_1069)">
-<path d="M14.553 16.0906C14.7408 16.5412 14.5603 18.2479 13.5648 18.6436C12.5692 19.0392 11.2972 18.6436 11.2972 18.6436L8.98909 14.0273L5 18.0164V0L17.22 12.22H12.6671C12.8905 12.6484 14.3145 15.5181 14.553 16.0906Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M6.07059 2.58464V15.4318L9.28237 12.22L11.9589 17.573C11.9589 17.573 12.6829 17.804 13.0295 17.573C13.376 17.3419 13.7207 16.8766 13.5648 16.5024C12.8285 14.7354 10.8883 11.1494 10.8883 11.1494H14.6353L6.07059 2.58464Z" fill="black"/>
-</g>
+<g filter="url(#filter0_d_1782_3558)">
+<path d="M5.32856 3.13114C5.19682 2.63568 5.64673 2.18231 6.13841 2.31507L16.8152 5.19787C17.4414 5.36696 17.4772 6.24882 16.8668 6.46886L11.9333 8.24724C11.4539 8.42007 11.0802 8.8059 10.9205 9.29311L9.43148 13.8344C9.22547 14.4627 8.33486 14.4369 8.16491 13.7978L5.32856 3.13114Z" fill="black"/>
+<path d="M4.60416 3.32388C4.32701 2.28161 5.27357 1.30534 6.33365 1.59146L17.0104 4.47427C18.3468 4.8351 18.4196 6.70626 17.1208 7.17447L12.1872 8.95279C11.9267 9.04681 11.7217 9.25787 11.6335 9.52701L10.1442 14.068C9.70522 15.4068 7.80173 15.3497 7.44009 13.9909L4.60416 3.32388Z" stroke="white" stroke-width="1.5"/>
 </g>
 <defs>
-<filter id="filter0_d_89_1069" x="2.6" y="-1.06667" width="17.02" height="23.6194" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1782_3558" x="3.80457" y="0.789246" width="17.0008" height="17.0025" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="1.33333"/>
-<feGaussianBlur stdDeviation="1.2"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1069"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1069" result="shape"/>
+<feOffset dx="1" dy="1"/>
+<feGaussianBlur stdDeviation="0.5"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3558"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3558" result="shape"/>
 </filter>
-<clipPath id="clip0_89_1069">
-<rect width="32" height="32" fill="white"/>
-</clipPath>
 </defs>
 </svg>

--- a/apps/desktop/src/renderer/public/cursors/cursor@64-bend.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@64-bend.svg
@@ -1,0 +1,64 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_1782_3645)">
+<path d="M10.6572 6.26228C10.3937 5.27137 11.2935 4.36462 12.2769 4.63014L33.6305 10.3957C34.8829 10.7339 34.9545 12.4976 33.7336 12.9377L23.8667 16.4945C22.9078 16.8401 22.1605 17.6118 21.841 18.5862C20.678 22.1332 20.026 24.1218 18.863 27.6687C18.451 28.9253 16.6698 28.8739 16.3299 27.5956L10.6572 6.26228Z" fill="black"/>
+<path d="M9.2074 6.64777C8.67039 4.62819 10.4317 2.73188 12.4701 3.13605L12.6683 3.18195L34.0219 8.94757C36.6942 9.66944 36.84 13.4124 34.2426 14.3489L24.3754 17.9056C23.8541 18.0935 23.4426 18.5155 23.266 19.054C22.6846 20.8272 22.2314 22.2113 21.7777 23.595C21.324 24.9789 20.8699 26.3626 20.2885 28.136C19.4104 30.8139 15.6031 30.6991 14.8802 27.9808L9.2074 6.64777Z" stroke="white" stroke-width="3"/>
+</g>
+<g filter="url(#filter1_d_1782_3645)">
+<mask id="path-3-outside-1_1782_3645" maskUnits="userSpaceOnUse" x="22.2016" y="17.0201" width="30.4056" height="30.4056" fill="black">
+<rect fill="white" x="22.2016" y="17.0201" width="30.4056" height="30.4056"/>
+<path d="M49.4008 25.5618C48.6791 24.84 47.7203 24.3695 46.5792 24.1769C45.4381 23.9844 44.1371 24.0736 42.7504 24.4396C41.3637 24.8056 39.9185 25.4411 38.4973 26.3099C37.0761 27.1787 35.7067 28.2637 34.4674 29.5031C33.2281 30.7424 32.143 32.1118 31.2742 33.533C30.4054 34.9542 29.7699 36.3994 29.4039 37.7861C29.038 39.1728 28.9487 40.4738 29.1412 41.6149C29.3338 42.756 29.8044 43.7148 30.5261 44.4365L33.2975 41.6652C32.7877 41.1554 32.4553 40.4781 32.3193 39.6721C32.1833 38.8661 32.2463 37.9472 32.5048 36.9677C32.7633 35.9882 33.2122 34.9674 33.8259 33.9635C34.4396 32.9597 35.206 31.9924 36.0814 31.117C36.9567 30.2416 37.924 29.4752 38.9278 28.8616C39.9317 28.2479 40.9525 27.799 41.932 27.5405C42.9115 27.282 43.8305 27.2189 44.6365 27.3549C45.4425 27.4909 46.1197 27.8233 46.6295 28.3331L49.4008 25.5618Z"/>
+</mask>
+<path d="M49.4008 25.5618C48.6791 24.84 47.7203 24.3695 46.5792 24.1769C45.4381 23.9844 44.1371 24.0736 42.7504 24.4396C41.3637 24.8056 39.9185 25.4411 38.4973 26.3099C37.0761 27.1787 35.7067 28.2637 34.4674 29.5031C33.2281 30.7424 32.143 32.1118 31.2742 33.533C30.4054 34.9542 29.7699 36.3994 29.4039 37.7861C29.038 39.1728 28.9487 40.4738 29.1412 41.6149C29.3338 42.756 29.8044 43.7148 30.5261 44.4365L33.2975 41.6652C32.7877 41.1554 32.4553 40.4781 32.3193 39.6721C32.1833 38.8661 32.2463 37.9472 32.5048 36.9677C32.7633 35.9882 33.2122 34.9674 33.8259 33.9635C34.4396 32.9597 35.206 31.9924 36.0814 31.117C36.9567 30.2416 37.924 29.4752 38.9278 28.8616C39.9317 28.2479 40.9525 27.799 41.932 27.5405C42.9115 27.282 43.8305 27.2189 44.6365 27.3549C45.4425 27.4909 46.1197 27.8233 46.6295 28.3331L49.4008 25.5618Z" fill="black"/>
+<path d="M49.4008 25.5618C48.6791 24.84 47.7203 24.3695 46.5792 24.1769C45.4381 23.9844 44.1371 24.0736 42.7504 24.4396C41.3637 24.8056 39.9185 25.4411 38.4973 26.3099C37.0761 27.1787 35.7067 28.2637 34.4674 29.5031C33.2281 30.7424 32.143 32.1118 31.2742 33.533C30.4054 34.9542 29.7699 36.3994 29.4039 37.7861C29.038 39.1728 28.9487 40.4738 29.1412 41.6149C29.3338 42.756 29.8044 43.7148 30.5261 44.4365L33.2975 41.6652C32.7877 41.1554 32.4553 40.4781 32.3193 39.6721C32.1833 38.8661 32.2463 37.9472 32.5048 36.9677C32.7633 35.9882 33.2122 34.9674 33.8259 33.9635C34.4396 32.9597 35.206 31.9924 36.0814 31.117C36.9567 30.2416 37.924 29.4752 38.9278 28.8616C39.9317 28.2479 40.9525 27.799 41.932 27.5405C42.9115 27.282 43.8305 27.2189 44.6365 27.3549C45.4425 27.4909 46.1197 27.8233 46.6295 28.3331L49.4008 25.5618Z" stroke="white" stroke-width="4" mask="url(#path-3-outside-1_1782_3645)"/>
+</g>
+<g filter="url(#filter2_d_1782_3645)">
+<circle cx="35.1635" cy="45.7606" r="4.8" fill="black"/>
+<circle cx="35.1635" cy="45.7606" r="3.8" stroke="white" stroke-width="2"/>
+</g>
+<g filter="url(#filter3_d_1782_3645)">
+<circle cx="51.1564" cy="29.5932" r="4.8" fill="black"/>
+<circle cx="51.1564" cy="29.5932" r="3.8" stroke="white" stroke-width="2"/>
+</g>
+<defs>
+<filter id="filter0_d_1782_3645" x="7.60919" y="1.57846" width="34.0015" height="34.005" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3645"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3645" result="shape"/>
+</filter>
+<filter id="filter1_d_1782_3645" x="20.6424" y="22.078" width="37.9869" height="37.987" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.4"/>
+<feGaussianBlur stdDeviation="3.2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3645"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3645" result="shape"/>
+</filter>
+<filter id="filter2_d_1782_3645" x="23.9635" y="40.9606" width="22.4" height="22.4" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.4"/>
+<feGaussianBlur stdDeviation="3.2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3645"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3645" result="shape"/>
+</filter>
+<filter id="filter3_d_1782_3645" x="39.9564" y="24.7932" width="22.4" height="22.4" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6.4"/>
+<feGaussianBlur stdDeviation="3.2"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3645"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3645" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/apps/desktop/src/renderer/public/cursors/cursor@64-copy.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@64-copy.svg
@@ -1,34 +1,36 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_196_213)">
-<g filter="url(#filter0_d_196_213)">
-<path d="M35.6976 30.4402C36.0061 31.1807 35.7096 33.9852 34.0737 34.6353C32.4378 35.2854 30.3476 34.6353 30.3476 34.6353L26.5549 27.0498L20 33.6047V4L40.08 24.08H32.5986C32.9658 24.784 35.3056 29.4995 35.6976 30.4402Z" fill="black"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M21.7592 8.2471V29.3576L27.0368 24.08L31.4348 32.876C31.4348 32.876 32.6246 33.2557 33.194 32.876C33.7635 32.4964 34.3299 31.7318 34.0736 31.1168C32.8639 28.2134 29.6756 22.3208 29.6756 22.3208H35.8328L21.7592 8.2471Z" fill="white"/>
+<g clip-path="url(#clip0_1782_3673)">
+<g filter="url(#filter0_d_1782_3673)">
+<path d="M21.7333 4.63177C21.1246 2.34191 23.1219 0.182572 25.4423 0.642517L25.6678 0.696228L45.2421 5.98138C48.2799 6.80197 48.4443 11.0522 45.493 12.1161L36.4481 15.3769C36.1517 15.4838 35.9141 15.7249 35.8114 16.038L33.0819 24.3632C32.0841 27.4065 27.7546 27.2756 26.9335 24.1874L21.7333 4.63177Z" stroke="white" stroke-width="3.99237" shape-rendering="crispEdges"/>
 </g>
-<g filter="url(#filter1_d_196_213)">
-<path d="M29.106 32.1812C29.4815 33.0825 29.1206 36.4959 27.1295 37.2871C25.1384 38.0784 22.5944 37.2871 22.5944 37.2871L17.9782 28.0547L10 36.0329V0L34.44 24.44H25.3342C25.7811 25.2969 28.6289 31.0362 29.106 32.1812Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M12.1412 5.16928V30.8636L18.5647 24.44L23.9177 35.1459C23.9177 35.1459 25.3658 35.608 26.0589 35.1459C26.752 34.6839 27.4414 33.7533 27.1295 33.0048C25.6571 29.4709 21.7765 22.2988 21.7765 22.2988H29.2707L12.1412 5.16928Z" fill="black"/>
+<path d="M22.5048 4.4267C22.0312 2.64514 23.6507 0.978262 25.4598 1.46674L45.0341 6.75189C47.3157 7.36835 47.4406 10.5653 45.2225 11.3652L36.1776 14.6249C35.6481 14.8158 35.2314 15.2439 35.0526 15.789L32.3231 24.1152C31.5732 26.4017 28.3223 26.3039 27.705 23.9824L22.5048 4.4267Z" fill="white" stroke="black" stroke-width="2.39542"/>
+<g filter="url(#filter1_d_1782_3673)">
+<path d="M10.6665 6.25898C10.403 5.26807 11.3028 4.36133 12.2862 4.62684L33.6397 10.3924C34.8922 10.7306 34.9638 12.4943 33.7429 12.9344L23.876 16.4912C22.9171 16.8368 22.1698 17.6085 21.8503 18.5829L18.8723 27.6654C18.4603 28.922 16.6791 28.8706 16.3391 27.5923L10.6665 6.25898Z" fill="black"/>
+<path d="M9.21667 6.64447C8.67967 4.62489 10.441 2.72859 12.4794 3.13275L12.6776 3.17865L34.0311 8.94427C36.7035 9.66615 36.8493 13.4091 34.2518 14.3456L24.3846 17.9023C23.8634 18.0902 23.4519 18.5122 23.2753 19.0507L20.2977 28.1328C19.4197 30.8106 15.6123 30.6958 14.8895 27.9775L9.21667 6.64447Z" stroke="white" stroke-width="3"/>
 </g>
 </g>
 <defs>
-<filter id="filter0_d_196_213" x="15.2" y="1.86667" width="29.68" height="40.5242" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1782_3673" x="14.196" y="-1.41879" width="40.846" height="40.8506" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="2.66667"/>
-<feGaussianBlur stdDeviation="2.4"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_196_213"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_196_213" result="shape"/>
+<feOffset dy="5.42962"/>
+<feGaussianBlur stdDeviation="2.71481"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.25 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3673"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3673" result="shape"/>
 </filter>
-<filter id="filter1_d_196_213" x="5.2" y="-2.13333" width="34.04" height="47.2388" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_d_1782_3673" x="7.61844" y="1.57516" width="34.0016" height="34.005" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="2.66667"/>
-<feGaussianBlur stdDeviation="2.4"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_196_213"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_196_213" result="shape"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3673"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3673" result="shape"/>
 </filter>
-<clipPath id="clip0_196_213">
+<clipPath id="clip0_1782_3673">
 <rect width="64" height="64" fill="white"/>
 </clipPath>
 </defs>

--- a/apps/desktop/src/renderer/public/cursors/cursor@64-moving.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@64-moving.svg
@@ -1,36 +1,32 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_95_218)">
-<g filter="url(#filter0_d_95_218)">
-<path d="M29.106 32.1812C29.4815 33.0825 29.1206 36.4959 27.1295 37.2871C25.1384 38.0784 22.5944 37.2871 22.5944 37.2871L17.9782 28.0547L10 36.0329V0L34.44 24.44H25.3342C25.7811 25.2969 28.6289 31.0362 29.106 32.1812Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M12.1412 5.16928V30.8636L18.5647 24.44L23.9177 35.1459C23.9177 35.1459 25.3658 35.608 26.0589 35.1459C26.752 34.6839 27.4414 33.7533 27.1295 33.0048C25.6571 29.4709 21.7765 22.2988 21.7765 22.2988H29.2707L12.1412 5.16928Z" fill="black"/>
+<g filter="url(#filter0_d_1782_3666)">
+<path d="M10.6665 6.25898C10.403 5.26807 11.3028 4.36133 12.2862 4.62684L33.6397 10.3924C34.8922 10.7306 34.9638 12.4943 33.7429 12.9344L23.876 16.4912C22.9171 16.8368 22.1698 17.6085 21.8503 18.5829L18.8723 27.6654C18.4603 28.922 16.6791 28.8706 16.3391 27.5923L10.6665 6.25898Z" fill="black"/>
+<path d="M9.21667 6.64447C8.67967 4.62489 10.441 2.72859 12.4794 3.13275L12.6776 3.17865L34.0311 8.94427C36.7035 9.66615 36.8493 13.4091 34.2518 14.3456L24.3846 17.9023C23.8634 18.0902 23.4519 18.5122 23.2753 19.0507L20.2977 28.1328C19.4197 30.8106 15.6123 30.6958 14.8895 27.9775L9.21667 6.64447Z" stroke="white" stroke-width="3"/>
 </g>
-<g filter="url(#filter1_d_95_218)">
-<path d="M42 34L28 48L37.135 57.135L42 62L56 48L42 34ZM38.5 53.25H36.75V51.5H38.5V53.25ZM38.5 44.5H36.75V42.75H38.5V44.5ZM47.25 53.25H45.5V51.5H47.25V53.25ZM45.5 42.75H47.25V44.5H45.5V42.75Z" fill="white"/>
-<path d="M53.4626 47.9651L48.9826 43.0476V46.2501H41.9826H34.9651V43.0476L30.4676 47.9651L34.9651 52.8826V49.7151H41.9826H48.9826V52.8826L53.4626 47.9651Z" fill="black"/>
-<path d="M43.6975 47.9826H43.715V40.9826H46.8825L41.9825 36.4851L37.065 40.9826H40.2325V47.9826V54.9826H37.0475L41.9475 59.4801L46.865 54.9826H43.6975V47.9826Z" fill="black"/>
-</g>
+<g filter="url(#filter1_d_1782_3666)">
+<path d="M43.4142 19.4142C42.6332 18.6332 41.3668 18.6332 40.5858 19.4142L29.4142 30.5858C28.6332 31.3668 28.6332 32.6332 29.4142 33.4142L37.135 41.135L40.5858 44.5858C41.3668 45.3668 42.6332 45.3668 43.4142 44.5858L54.5858 33.4142C55.3668 32.6332 55.3668 31.3668 54.5858 30.5858L43.4142 19.4142ZM38.5 37.25H36.75V35.5H38.5V37.25ZM38.5 28.5H36.75V26.75H38.5V28.5ZM47.25 37.25H45.5V35.5H47.25V37.25ZM45.5 26.75H47.25V28.5H45.5V26.75Z" fill="white"/>
+<path d="M53.4627 31.965L48.9827 27.0475V30.25H41.9827H34.9652V27.0475L30.4677 31.965L34.9652 36.8825V33.715H41.9827H48.9827V36.8825L53.4627 31.965Z" fill="black"/>
+<path d="M43.6975 31.9825H43.715V24.9825H46.8825L41.9825 20.485L37.065 24.9825H40.2325V31.9825V38.9825H37.0475L41.9475 43.48L46.865 38.9825H43.6975V31.9825Z" fill="black"/>
 </g>
 <defs>
-<filter id="filter0_d_95_218" x="5.2" y="-2.13333" width="34.04" height="47.2388" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1782_3666" x="7.61847" y="1.57516" width="34.0015" height="34.005" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="2.66667"/>
-<feGaussianBlur stdDeviation="2.4"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_95_218"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_95_218" result="shape"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3666"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3666" result="shape"/>
 </filter>
-<filter id="filter1_d_95_218" x="24.4" y="32.4" width="35.2" height="35.2" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter1_d_1782_3666" x="25.2284" y="17.2284" width="33.5431" height="33.5431" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
 <feOffset dy="2"/>
 <feGaussianBlur stdDeviation="1.8"/>
 <feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_95_218"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_95_218" result="shape"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3666"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3666" result="shape"/>
 </filter>
-<clipPath id="clip0_95_218">
-<rect width="64" height="64" fill="white"/>
-</clipPath>
 </defs>
 </svg>

--- a/apps/desktop/src/renderer/public/cursors/cursor@64.svg
+++ b/apps/desktop/src/renderer/public/cursors/cursor@64.svg
@@ -1,22 +1,18 @@
 <svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<g clip-path="url(#clip0_89_1101)">
-<g filter="url(#filter0_d_89_1101)">
-<path d="M29.106 32.1812C29.4815 33.0825 29.1206 36.4959 27.1295 37.2871C25.1384 38.0784 22.5944 37.2871 22.5944 37.2871L17.9782 28.0547L10 36.0329V0L34.44 24.44H25.3342C25.7811 25.2969 28.6289 31.0362 29.106 32.1812Z" fill="white"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M12.1411 5.16928V30.8636L18.5647 24.44L23.9177 35.1459C23.9177 35.1459 25.3658 35.608 26.0589 35.1459C26.752 34.6839 27.4414 33.7533 27.1295 33.0048C25.657 29.4709 21.7765 22.2988 21.7765 22.2988H29.2707L12.1411 5.16928Z" fill="black"/>
-</g>
+<g filter="url(#filter0_d_1782_3561)">
+<path d="M10.6572 6.26222C10.3937 5.27131 11.2935 4.36456 12.2769 4.63008L33.6304 10.3957C34.8829 10.7339 34.9545 12.4976 33.7336 12.9377L23.8667 16.4944C22.9078 16.8401 22.1605 17.6117 21.841 18.5862L18.863 27.6687C18.451 28.9253 16.6698 28.8738 16.3298 27.5955L10.6572 6.26222Z" fill="black"/>
+<path d="M9.20737 6.64771C8.67036 4.62813 10.4317 2.73182 12.4701 3.13599L12.6683 3.18188L34.0218 8.94751C36.6942 9.66938 36.84 13.4124 34.2425 14.3489L24.3753 17.9055C23.8541 18.0934 23.4425 18.5154 23.266 19.054L20.2884 28.136C19.4104 30.8139 15.603 30.699 14.8802 27.9807L9.20737 6.64771Z" stroke="white" stroke-width="3"/>
 </g>
 <defs>
-<filter id="filter0_d_89_1101" x="5.2" y="-2.13333" width="34.04" height="47.2388" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<filter id="filter0_d_1782_3561" x="7.60913" y="1.5784" width="34.0016" height="34.005" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
 <feFlood flood-opacity="0" result="BackgroundImageFix"/>
 <feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
-<feOffset dy="2.66667"/>
-<feGaussianBlur stdDeviation="2.4"/>
-<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.65 0"/>
-<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_89_1101"/>
-<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_89_1101" result="shape"/>
+<feOffset dx="2" dy="2"/>
+<feGaussianBlur stdDeviation="1"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.2 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_1782_3561"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_1782_3561" result="shape"/>
 </filter>
-<clipPath id="clip0_89_1101">
-<rect width="64" height="64" fill="white"/>
-</clipPath>
 </defs>
 </svg>

--- a/apps/desktop/src/renderer/src/app/App.css
+++ b/apps/desktop/src/renderer/src/app/App.css
@@ -4,15 +4,8 @@ body {
   overflow: hidden;
 }
 
-.shift-editor-shell {
+.shift-editor-shell #interactive-canvas {
   cursor: var(--shift-cursor);
-}
-
-.shift-editor-shell[data-gesture="pressed"],
-.shift-editor-shell[data-gesture="dragging"],
-.shift-editor-shell[data-gesture="pressed"] *,
-.shift-editor-shell[data-gesture="dragging"] * {
-  cursor: var(--shift-cursor) !important;
 }
 
 /* Custom pen cursor with retina support */

--- a/apps/desktop/src/renderer/src/lib/styles/cursor.test.ts
+++ b/apps/desktop/src/renderer/src/lib/styles/cursor.test.ts
@@ -10,6 +10,7 @@ const CUSTOM_CURSORS: CursorType[] = [
   { type: "default" },
   { type: "move" },
   { type: "copy" },
+  { type: "bend" },
   { type: "pen" },
   { type: "pen-add" },
   { type: "pen-end" },

--- a/apps/desktop/src/renderer/src/lib/styles/cursor.ts
+++ b/apps/desktop/src/renderer/src/lib/styles/cursor.ts
@@ -8,6 +8,8 @@ export function cursorToCSS(cursor: CursorType): string {
       return `-webkit-image-set(url("../cursors/cursor@32-moving.svg") 1x, url("../cursors/cursor@64-moving.svg") 2x) 5 0, move`;
     case "copy":
       return `-webkit-image-set(url("../cursors/cursor@32-copy.svg") 1x, url("../cursors/cursor@64-copy.svg") 2x) 5 0, copy`;
+    case "bend":
+      return `-webkit-image-set(url("../cursors/cursor@32-bend.svg") 1x, url("../cursors/cursor@64-bend.svg") 2x) 5 0, default`;
     case "pen":
       return `-webkit-image-set(url("../cursors/pen@32.svg") 1x, url("../cursors/pen@64.svg") 2x) 8 8, crosshair`;
     case "pen-add":

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -17,6 +17,7 @@ import {
 } from "./behaviors";
 import { TextRunHover } from "./behaviors/TextRunHover";
 import type { CursorType } from "@/types/editor";
+import { objectIsKindOf } from "@/types";
 import type { Canvas } from "@/lib/editor/rendering/Canvas";
 import { SelectBoundingBox } from "./BoundingBox";
 import { SelectMarquee } from "./Marquee";
@@ -47,22 +48,41 @@ export class Select extends BaseTool<SelectState, Select> {
   override getCursor(state: SelectState): CursorType {
     if (this.editor.sessionMode === "preview") return { type: "default" };
 
-    if (state.type === "translating") return { type: "move" };
-    if (state.type === "resizing") return edgeToCursor(state.resize.edge);
-    if (state.type === "rotating") {
-      return this.boundingBox.cursorForRotationCorner(state.rotate.corner);
+    switch (state.type) {
+      case "translating":
+        return { type: "move" };
+      case "resizing":
+        return edgeToCursor(state.resize.edge);
+      case "rotating":
+        return this.boundingBox.cursorForRotationCorner(state.rotate.corner);
+      case "bending":
+        return { type: "bend" };
     }
 
     const coords = this.editor.input.pointerCell.value;
     if (coords) {
       const cursor = this.boundingBox.cursor(coords);
       if (cursor) return cursor;
-
-      if (this.boundingBox.containsTranslationPoint(coords)) return { type: "move" };
     }
 
     const modifiers = this.editor.input.modifiersCell.value;
     const hover = this.editor.hover.entryCell.value;
+    if (state.type === "ready" && coords && modifiers.metaKey && hover) {
+      const object = this.editor.object(hover);
+      if (objectIsKindOf(object, "segment")) {
+        const layer = object.layer;
+        if (
+          layer &&
+          layer.sourceId === this.editor.activeSourceIdCell.value &&
+          layer.segment(object.segmentId)?.asCubic()
+        ) {
+          return { type: "bend" };
+        }
+      }
+    }
+
+    if (coords && this.boundingBox.containsTranslationPoint(coords)) return { type: "move" };
+
     if (modifiers.altKey && hover) {
       return { type: "copy" };
     }

--- a/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/SelectTransform.test.ts
@@ -23,6 +23,13 @@ describe("Select bounding-box transforms preserve geometry outcomes", () => {
     editor.selectTool("select");
   });
 
+  it("does not offer bending on a straight segment inside the selection", () => {
+    const down = editor.projectSceneToScreen({ x: 150, y: 150 });
+    editor.pointerMove(down.x, down.y, { metaKey: true });
+
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "move" });
+  });
+
   describe("resizing", () => {
     it("changes only X when dragging the right edge", async () => {
       const bounds = editor.selectionBounds();
@@ -261,6 +268,40 @@ describe("Select curve bending preserves edit lifecycle", () => {
     editor.selectTool("select");
   });
 
+  it("shows the bend cursor when Meta is pressed over a cubic, and clears it on release", () => {
+    const down = editor.projectSceneToScreen(bendPoint);
+    editor.pointerMove(down.x, down.y);
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
+
+    editor.keyDown("Meta", { metaKey: true });
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "bend" });
+
+    editor.pointerMove(down.x, down.y);
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
+  });
+
+  it("does not offer bending on a point or empty canvas", () => {
+    const down = editor.projectSceneToScreen({ x: 100, y: 200 });
+    editor.pointerMove(down.x, down.y, { metaKey: true });
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
+
+    editor.pointerMove(down.x + 300, down.y + 300, { metaKey: true });
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
+  });
+
+  it("keeps the bend cursor during a drag even after Meta is released", async () => {
+    const down = editor.projectSceneToScreen(bendPoint);
+    editor.pointerDown(down.x, down.y, { metaKey: true });
+    editor.pointerMove(down.x + 4, down.y, { metaKey: true });
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "bend" });
+
+    editor.pointerMove(down.x + 4, down.y + 40);
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "bend" });
+    editor.pointerUp(down.x + 4, down.y + 40);
+    await editor.settle();
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
+  });
+
   it("restores both controls when Escape cancels bending", () => {
     const oneBefore = editor.pointPosition(controlOneId);
     const twoBefore = editor.pointPosition(controlTwoId);
@@ -272,8 +313,10 @@ describe("Select curve bending preserves edit lifecycle", () => {
     editor.pointerMove(start.x, start.y, { metaKey: true });
     editor.pointerMove(end.x, end.y, { metaKey: true });
     expect(editor.pointPosition(controlOneId)).not.toEqual(oneBefore);
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "bend" });
     editor.escape();
 
+    expect(editor.toolManager.activeTool?.cursorCell.value).toEqual({ type: "default" });
     expect(editor.pointPosition(controlOneId)).toEqual(oneBefore);
     expect(editor.pointPosition(controlTwoId)).toEqual(twoBefore);
   });

--- a/apps/desktop/src/renderer/src/types/editor.ts
+++ b/apps/desktop/src/renderer/src/types/editor.ts
@@ -9,6 +9,7 @@ export type CursorType =
   | { type: "grabbing" }
   | { type: "move" }
   | { type: "copy" }
+  | { type: "bend" }
   | { type: "crosshair" }
   | { type: "pen" }
   | { type: "pen-add" }


### PR DESCRIPTION
## Summary

- Refresh the arrow, move, and copy cursor artwork and add matching bend cursors at 1× and 2× resolution.
- Show bend feedback on Command-hover over an editable cubic and throughout bending, without changing gesture transitions or resize/rotation priority.
- Keep custom tool cursors on the interactive canvas, never the sidebars, including during captured drags across sidebar boundaries.
- Add cursor lifecycle and Electron interaction coverage, and mark curve bending complete in the roadmap.

## Issue

Closes #364

## Testing

Passed:
- `pnpm test` — all 11 Turbo tasks succeeded; desktop suite: 84 files, 815 tests.
- `pnpm test:desktop src/renderer/src/lib/tools/select src/renderer/src/lib/styles/cursor.test.ts` — 106 tests passed.
- `pnpm format:check`
- `pnpm lint:check`
- `pnpm typecheck`
- `~/.pi/agent/bin/shift-remote-e2e visual e2e/editor.spec.ts --grep 'keeps custom cursors'` — passed on macOS; exercises Command-hover, bending, and cursor isolation while crossing both sidebars.
- Commit hooks, including strict dead-code checks.

Not run: the complete visual, GPU, and platform E2E suites; this change is limited to cursor artwork, cursor selection, and CSS scope, with the affected interaction covered by the focused visual test.

## UI review evidence

The SVG diffs contain the actual before/after arrow, move, and copy artwork and both new bend assets. Playwright page screenshots do not capture the operating-system cursor, so screenshots would not reliably show this change. The Electron test verifies computed cursor selection and sidebar isolation in hover, pressed, and dragging states; it is not a pixel-level cursor screenshot comparison.
