### PR TITLE
refactor(workspace): identify document history entries

### DIFF
--- a/apps/desktop/src/renderer/src/lib/workspace/FontSessionClient.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/FontSessionClient.ts
@@ -24,6 +24,7 @@ import type {
   GlyphPreview,
   GlyphSnapshot,
   GlyphProjection,
+  LedgerEntryId,
   Location,
   SlugAtlas,
 } from "@shift/types";
@@ -106,22 +107,42 @@ export class FontSessionClient {
     return this.#fold(applied);
   }
 
-  /** Replays the latest ledger entry; null when nothing is undoable. */
-  async undo(): Promise<AppliedChange | null> {
+  /**
+   * Replays the latest ledger entry, optionally requiring its stable identity.
+   *
+   * @param entryId - Expected next entry; mismatch rejects without replaying another edit.
+   * @returns The applied replacement, or null when ordinary undo has no entry.
+   */
+  async undo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     await this.connect();
 
-    const { applied, documentState } = await this.#require().call("workspace.undo", undefined);
-    this.documentStateCell.set(documentState);
-    return applied === null ? null : this.#fold(applied);
+    const response = entryId
+      ? await this.#require().call("workspace.undoEntry", { entryId })
+      : await this.#require().call("workspace.undo", undefined);
+    this.documentStateCell.set(response.documentState);
+    return response.applied === null ? null : this.#fold(response.applied);
   }
 
-  /** Replays the latest undone entry; null when nothing is redoable. */
-  async redo(): Promise<AppliedChange | null> {
+  /**
+   * Replays the latest undone entry, optionally requiring its stable identity.
+   *
+   * @param entryId - Expected next entry; mismatch rejects without replaying another edit.
+   * @returns The applied replacement, or null when ordinary redo has no entry.
+   */
+  async redo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     await this.connect();
 
-    const { applied, documentState } = await this.#require().call("workspace.redo", undefined);
-    this.documentStateCell.set(documentState);
-    return applied === null ? null : this.#fold(applied);
+    const response = entryId
+      ? await this.#require().call("workspace.redoEntry", { entryId })
+      : await this.#require().call("workspace.redo", undefined);
+    this.documentStateCell.set(response.documentState);
+    return response.applied === null ? null : this.#fold(response.applied);
+  }
+
+  /** Permanently removes the current document redo branch without changing font state. */
+  async discardRedo(): Promise<void> {
+    await this.connect();
+    await this.#require().call("workspace.discardRedo", undefined);
   }
 
   async snapshot(): Promise<WorkspaceSnapshot | null> {

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.ts
@@ -5,6 +5,7 @@ import type {
   GlyphPreview,
   GlyphProjection,
   GlyphSnapshot,
+  LedgerEntryId,
   Location,
   SlugAtlas,
 } from "@shift/types";
@@ -174,10 +175,15 @@ export class WorkspaceEditCoordinator {
     });
   }
 
-  /** Replays the latest undo entry after pending pushes flush. */
-  undo(): Promise<AppliedChange | null> {
+  /**
+   * Replays the latest undo entry after pending pushes flush.
+   *
+   * @param entryId - Expected next entry; mismatch rejects without replaying another edit.
+   * @returns The applied replacement, or null when ordinary undo has no entry.
+   */
+  undo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     return this.#withFlush(async () => {
-      const applied = await this.#session.undo();
+      const applied = await this.#session.undo(entryId);
       if (applied) await this.#applyChange(applied, null);
       return applied;
     });
@@ -259,13 +265,23 @@ export class WorkspaceEditCoordinator {
     return this.#withFlush(() => this.#session.mapLocation(location));
   }
 
-  /** Replays the latest redo entry after pending pushes flush. */
-  redo(): Promise<AppliedChange | null> {
+  /**
+   * Replays the latest redo entry after pending pushes flush.
+   *
+   * @param entryId - Expected next entry; mismatch rejects without replaying another edit.
+   * @returns The applied replacement, or null when ordinary redo has no entry.
+   */
+  redo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     return this.#withFlush(async () => {
-      const applied = await this.#session.redo();
+      const applied = await this.#session.redo(entryId);
       if (applied) await this.#applyChange(applied, null);
       return applied;
     });
+  }
+
+  /** Permanently removes the current document redo branch after pending operations flush. */
+  discardRedo(): Promise<void> {
+    return this.#withFlush(() => this.#session.discardRedo());
   }
 
   /** Reads document state behind every queued and in-flight edit. */

--- a/apps/desktop/src/shared/workspace/protocol.ts
+++ b/apps/desktop/src/shared/workspace/protocol.ts
@@ -15,6 +15,7 @@ import type {
   GlyphRecord,
   GlyphState,
   GlyphSnapshot,
+  LedgerEntryId,
   Location,
   MetricDefinition,
   SourceMetricsInterpolationSnapshot,
@@ -259,6 +260,14 @@ export type SyncCallMap = {
       documentState: WorkspaceDocumentState | null;
     };
   };
+  /** Replays `entryId` only when it is the next ordinary undo entry. */
+  "workspace.undoEntry": {
+    request: { entryId: LedgerEntryId };
+    response: {
+      applied: AppliedChange | null;
+      documentState: WorkspaceDocumentState | null;
+    };
+  };
   "workspace.redo": {
     request: void;
     response: {
@@ -266,6 +275,16 @@ export type SyncCallMap = {
       documentState: WorkspaceDocumentState | null;
     };
   };
+  /** Replays `entryId` only when it is the next ordinary redo entry. */
+  "workspace.redoEntry": {
+    request: { entryId: LedgerEntryId };
+    response: {
+      applied: AppliedChange | null;
+      documentState: WorkspaceDocumentState | null;
+    };
+  };
+  /** Permanently removes the current document redo branch without changing font state. */
+  "workspace.discardRedo": { request: void; response: null };
   /**
    * Saves to the current canonical document, or rejects when the workspace still
    * needs a path. Rides the edit lane so the utility serializes it behind every

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.test.ts
@@ -1180,7 +1180,7 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
     const contourId = mintContourId();
     const p1 = mintPointId();
 
-    await applyWorkspace(sync, {
+    const drawn = await applyWorkspace(sync, {
       intents: [
         { kind: "addContour", addContour: { layerId, contourId, closed: false } },
         {
@@ -1194,12 +1194,33 @@ describe("WorkspaceHost serves the workspace over transferred ports", () => {
       ],
       label: "Draw",
     });
+    if (!drawn.ledgerEntryId) throw new Error("workspace apply did not identify its ledger entry");
 
-    const undone = await undoWorkspace(sync);
+    const undone = (await sync.call("workspace.undoEntry", { entryId: drawn.ledgerEntryId }))
+      .applied;
+    expect(undone?.ledgerEntryId).toBe(drawn.ledgerEntryId);
     expect(undone?.layers[0].structure?.contours).toEqual([]);
 
-    const redone = await redoWorkspace(sync);
+    const redone = (await sync.call("workspace.redoEntry", { entryId: drawn.ledgerEntryId }))
+      .applied;
+    expect(redone?.ledgerEntryId).toBe(drawn.ledgerEntryId);
     expect(redone?.layers[0].structure?.contours[0].points.map((point) => point.id)).toEqual([p1]);
+  });
+
+  it("discarding redo prevents replay without changing document state", async () => {
+    const sync = await connectSyncLane();
+    const snapshot = await createWorkspace(sync);
+    const created = await applyWorkspace(sync, {
+      intents: createGlyphALayer(snapshot.sources[0].id).intents,
+    });
+    expect(created.ledgerEntryId).toBeDefined();
+
+    await undoWorkspace(sync);
+    const before = await sync.call("document.state", undefined);
+    await sync.call("workspace.discardRedo", undefined);
+
+    await expect(redoWorkspace(sync)).resolves.toBeNull();
+    await expect(sync.call("document.state", undefined)).resolves.toEqual(before);
   });
 
   it("undo on an empty ledger answers null", async () => {

--- a/apps/desktop/src/utility/workspace/WorkspaceHost.ts
+++ b/apps/desktop/src/utility/workspace/WorkspaceHost.ts
@@ -1,5 +1,5 @@
 import { createBridge, type ShiftBridge } from "@shift/bridge";
-import type { GlyphSnapshot } from "@shift/types";
+import type { AppliedChange, GlyphSnapshot, LedgerEntryId } from "@shift/types";
 import fs from "node:fs";
 import path from "node:path";
 import { serveChannel, type ChannelServer, type Transport } from "../../shared/workspace/channel";
@@ -161,19 +161,14 @@ export class WorkspaceHost {
           this.#atlasCacheRevision = null;
           return { applied, documentState: this.#emitDocumentChanged() };
         }),
-      "workspace.undo": () =>
+      "workspace.undo": () => this.#serialize(() => this.#replay("undo")),
+      "workspace.undoEntry": ({ entryId }) => this.#serialize(() => this.#replay("undo", entryId)),
+      "workspace.redo": () => this.#serialize(() => this.#replay("redo")),
+      "workspace.redoEntry": ({ entryId }) => this.#serialize(() => this.#replay("redo", entryId)),
+      "workspace.discardRedo": () =>
         this.#serialize(() => {
-          const applied = this.#bridge.undo();
-          if (applied) this.#atlasCacheRevision = null;
-          const documentState = applied ? this.#emitDocumentChanged() : this.#documentState();
-          return { applied, documentState };
-        }),
-      "workspace.redo": () =>
-        this.#serialize(() => {
-          const applied = this.#bridge.redo();
-          if (applied) this.#atlasCacheRevision = null;
-          const documentState = applied ? this.#emitDocumentChanged() : this.#documentState();
-          return { applied, documentState };
+          this.#bridge.discardRedo();
+          return null;
         }),
       // Save rides the edit lane: the same #serialize queue orders it behind
       // every committed apply/undo/redo, so it never writes stale state.
@@ -794,6 +789,26 @@ export class WorkspaceHost {
     this.#sync?.emit("document.changed", null);
 
     return null;
+  }
+
+  #replay(
+    direction: "undo" | "redo",
+    entryId?: LedgerEntryId,
+  ): SyncCallMap["workspace.undo"]["response"] {
+    let applied: AppliedChange | null;
+
+    switch (direction) {
+      case "undo":
+        applied = entryId ? this.#bridge.undoEntry(entryId) : this.#bridge.undo();
+        break;
+      case "redo":
+        applied = entryId ? this.#bridge.redoEntry(entryId) : this.#bridge.redo();
+        break;
+    }
+
+    if (applied) this.#atlasCacheRevision = null;
+    const documentState = applied ? this.#emitDocumentChanged() : this.#documentState();
+    return { applied, documentState };
   }
 
   #documentState(): WorkspaceDocumentState | null {

--- a/crates/shift-bridge/docs/DOCS.md
+++ b/crates/shift-bridge/docs/DOCS.md
@@ -1,6 +1,6 @@
 # shift-bridge
 
-<!-- reviewed: 2026-09-01 review-every: 90d -->
+<!-- reviewed: 2026-09-06 review-every: 90d -->
 
 NAPI bindings that expose the Rust font engine to Node.js and Electron as a `Bridge` class.
 

--- a/crates/shift-bridge/docs/DOCS.md
+++ b/crates/shift-bridge/docs/DOCS.md
@@ -46,7 +46,7 @@ crates/shift-bridge/
 - `NapiDocumentIdentity` -- canonical `DocumentId` and canonical path used by utility/main document lifecycle decisions.
 - `ExportFontTask` -- NAPI `Task` implementation for async font export.
 - `BridgeError` -- typed bridge error enum converted once at the NAPI boundary.
-- `NapiAppliedChange` -- replace-grade mutation response returned by apply/undo/redo.
+- `NapiAppliedChange` -- replace-grade mutation response returned by apply/undo/redo, carrying the stable ledger entry identity when an entry was created or replayed.
 - `NapiFontReplacement` -- selective complete font projections; metadata is present only when an edit replaced it.
 - `NapiUpdateFontMetadataIntent` -- complete authored metadata replacement payload that leaves metrics unchanged.
 - `NapiLayerReplaced` -- NAPI adapter for one replaced glyph layer in an applied change.
@@ -65,7 +65,7 @@ crates/shift-bridge/
 1. The renderer resolves glyph state with `GlyphHandle + SourceId` and receives a stable `layerId`.
 2. JS batches one or more `NapiFontIntent` values (kind discriminator plus one populated payload field, e.g. "setContourClosed") into a single `apply(intents, label?)` call; the optional `label` string names the resulting undo ledger entry. `apply`, `undo`, and `redo` are the only mutation entry points — there are no per-mutation NAPI methods.
 3. `Bridge` decodes each intent through `map_intent`, parsing boundary strings into typed IDs, and forwards the set as one atomic `FontWorkspace` apply: one SQLite transaction, one undo step.
-4. The bridge returns a pure-state `NapiAppliedChange` — replaced layers, optional font-level replacement collections, and `dependents: Array<GlyphId>` naming the composite glyphs that reference the touched layers; no change records cross to the renderer — and bumps the live version.
+4. The bridge returns a pure-state `NapiAppliedChange` — the stable process-local `LedgerEntryId`, replaced layers, optional font-level replacement collections, and `dependents: Array<GlyphId>` naming the composite glyphs that reference the touched layers; no change records cross to the renderer — and bumps the live version. Identified undo/redo rejects when that entry is not next, while `discardRedo()` truncates the document redo branch without changing font or dirty state.
 5. Full glyph snapshots first acquire requested layer payloads, then include authored state plus the same `GlyphProjection` used by lightweight reads. `getGlyphProjections()` and previews expand transitive component identities through SQLite indexes, acquire those layers, and only then project without further I/O. Source reads expose master sources only; layer-only/background sources remain native authoring details and never enter renderer interpolation.
 6. `saveWorkspace()` applies a document's sparse recovery overlay to its canonical SQLite file. `saveWorkspaceAsDocument(path, recoveryPath)` publishes a new native document identity and adopts its fresh overlay; `discardWorkspaceChanges()` clears recovery and reloads canonical directory state.
 7. `inspectDocument(path)` exposes canonical identity without opening a live workspace. `openDocument(path, recoveryPath)` opens merged lazy views selected by the utility process.

--- a/crates/shift-bridge/dts-header.d.ts
+++ b/crates/shift-bridge/dts-header.d.ts
@@ -10,6 +10,7 @@ import type {
   GlyphId,
   GlyphName,
   LayerId,
+  LedgerEntryId,
   MetricId,
   NamedInstanceId,
   SourceId,

--- a/crates/shift-bridge/index.d.ts
+++ b/crates/shift-bridge/index.d.ts
@@ -10,6 +10,7 @@ import type {
   GlyphId,
   GlyphName,
   LayerId,
+  LedgerEntryId,
   MetricId,
   NamedInstanceId,
   SourceId,
@@ -46,11 +47,17 @@ export declare class Bridge {
    * undo stack is empty.
    */
   undo(): NapiAppliedChange | null
+  /** Replays one identified entry only when it is next in the undo stack. */
+  undoEntry(entryId: LedgerEntryId): NapiAppliedChange | null
   /**
    * Replays the most recent undone entry's post states; `null` when the
    * redo stack is empty.
    */
   redo(): NapiAppliedChange | null
+  /** Replays one identified entry only when it is next in the redo stack. */
+  redoEntry(entryId: LedgerEntryId): NapiAppliedChange | null
+  /** Permanently removes every currently undone document entry. */
+  discardRedo(): void
   /** Glyph-addressed snapshots for renderer-local synchronous font state. */
   getGlyphSnapshots(requests: Array<NapiGlyphSnapshotRequest>): Array<NapiGlyphSnapshot>
   /**
@@ -189,6 +196,8 @@ export interface NapiAnchorSeed {
 
 /** Pure-state response to `apply`: no change records cross to the renderer. */
 export interface NapiAppliedChange {
+  /** Stable identity of the document ledger entry, absent for an empty apply. */
+  ledgerEntryId?: LedgerEntryId
   layers: Array<NapiLayerReplaced>
   /** Present when the apply produced any font-level replacement collections. */
   next?: NapiFontReplacement

--- a/crates/shift-bridge/src/bridge.rs
+++ b/crates/shift-bridge/src/bridge.rs
@@ -46,7 +46,8 @@ use shift_wire::{
   SourceMetricValue, SourceMetricsInterpolationSnapshot, VariationBasis, VariationDelta,
 };
 use shift_workspace::{
-  AcquireScope, DocumentIdentity, FontWorkspace, NewWorkspace, WorkspaceError, WorkspaceSource,
+  AcquireScope, DocumentIdentity, FontWorkspace, LedgerEntryId, NewWorkspace, WorkspaceError,
+  WorkspaceSource,
 };
 use std::{
   collections::{BTreeMap, HashMap, HashSet, VecDeque},
@@ -1306,6 +1307,7 @@ impl Bridge {
   ) -> errors::Result<NapiAppliedChange> {
     if intents.is_empty() {
       return Ok(NapiAppliedChange {
+        ledger_entry_id: None,
         layers: Vec::new(),
         next: None,
         dependents: Vec::new(),
@@ -1317,17 +1319,21 @@ impl Bridge {
       set.intents.push(map_intent(intent)?);
     }
 
-    let outcome = self.workspace_mut()?.apply(set, label)?;
+    let (entry_id, outcome) = self.workspace_mut()?.apply_with_entry_id(set, label)?;
     self.mark_font_changed();
 
-    self.applied_echo(outcome)
+    self.applied_echo(entry_id, outcome)
   }
 
   /// Assembles the pure-state echo for an applied outcome: replace-grade
   /// layers plus dependent composites. Shared by apply/undo/redo. The
   /// records grain (glyphs/axes/sources lists) rides along whenever the
   /// change set touched that structure.
-  fn applied_echo(&self, outcome: shift_font::AppliedIntents) -> errors::Result<NapiAppliedChange> {
+  fn applied_echo(
+    &self,
+    entry_id: LedgerEntryId,
+    outcome: shift_font::AppliedIntents,
+  ) -> errors::Result<NapiAppliedChange> {
     let mut metadata_changed = false;
     let mut glyphs_changed = false;
     let mut axes_changed = false;
@@ -1425,6 +1431,7 @@ impl Bridge {
       .transpose()?;
 
     Ok(NapiAppliedChange {
+      ledger_entry_id: Some(entry_id.to_string()),
       layers,
       next,
       dependents,
@@ -1435,24 +1442,83 @@ impl Bridge {
   /// undo stack is empty.
   #[napi]
   pub fn undo(&mut self) -> errors::Result<Option<NapiAppliedChange>> {
-    let Some(outcome) = self.workspace_mut()?.undo()? else {
+    self.undo_with_entry_id(None)
+  }
+
+  /// Replays one identified entry only when it is next in the undo stack.
+  #[napi(ts_args_type = "entryId: LedgerEntryId")]
+  pub fn undo_entry(&mut self, entry_id: String) -> errors::Result<Option<NapiAppliedChange>> {
+    self.undo_with_entry_id(Some(parse::<LedgerEntryId>(&entry_id)?))
+  }
+
+  fn undo_with_entry_id(
+    &mut self,
+    expected: Option<LedgerEntryId>,
+  ) -> errors::Result<Option<NapiAppliedChange>> {
+    let entry_id = match expected {
+      Some(entry_id) => entry_id,
+      None => {
+        let Some(entry_id) = self.workspace()?.next_undo_entry_id() else {
+          return Ok(None);
+        };
+        entry_id
+      }
+    };
+    let outcome = match expected {
+      Some(_) => self.workspace_mut()?.undo_entry(entry_id)?,
+      None => self.workspace_mut()?.undo()?,
+    };
+    let Some(outcome) = outcome else {
       return Ok(None);
     };
 
     self.mark_font_changed();
-    Ok(Some(self.applied_echo(outcome)?))
+    Ok(Some(self.applied_echo(entry_id, outcome)?))
   }
 
   /// Replays the most recent undone entry's post states; `null` when the
   /// redo stack is empty.
   #[napi]
   pub fn redo(&mut self) -> errors::Result<Option<NapiAppliedChange>> {
-    let Some(outcome) = self.workspace_mut()?.redo()? else {
+    self.redo_with_entry_id(None)
+  }
+
+  /// Replays one identified entry only when it is next in the redo stack.
+  #[napi(ts_args_type = "entryId: LedgerEntryId")]
+  pub fn redo_entry(&mut self, entry_id: String) -> errors::Result<Option<NapiAppliedChange>> {
+    self.redo_with_entry_id(Some(parse::<LedgerEntryId>(&entry_id)?))
+  }
+
+  fn redo_with_entry_id(
+    &mut self,
+    expected: Option<LedgerEntryId>,
+  ) -> errors::Result<Option<NapiAppliedChange>> {
+    let entry_id = match expected {
+      Some(entry_id) => entry_id,
+      None => {
+        let Some(entry_id) = self.workspace()?.next_redo_entry_id() else {
+          return Ok(None);
+        };
+        entry_id
+      }
+    };
+    let outcome = match expected {
+      Some(_) => self.workspace_mut()?.redo_entry(entry_id)?,
+      None => self.workspace_mut()?.redo()?,
+    };
+    let Some(outcome) = outcome else {
       return Ok(None);
     };
 
     self.mark_font_changed();
-    Ok(Some(self.applied_echo(outcome)?))
+    Ok(Some(self.applied_echo(entry_id, outcome)?))
+  }
+
+  /// Permanently removes every currently undone document entry.
+  #[napi]
+  pub fn discard_redo(&mut self) -> errors::Result<()> {
+    self.workspace_mut()?.discard_redo();
+    Ok(())
   }
 
   /// Glyph-addressed snapshots for renderer-local synchronous font state.

--- a/crates/shift-bridge/src/input.rs
+++ b/crates/shift-bridge/src/input.rs
@@ -4,6 +4,7 @@ use shift_font::{
   AnchorId, AxisId, AxisLabelId, AxisMappingId, ComponentId, ContourId, GlyphId, GuidelineId,
   LayerId, MetricId, NamedInstanceId, PointId, SourceId,
 };
+use shift_workspace::LedgerEntryId;
 
 use crate::errors::{BridgeError, BridgeResult};
 
@@ -72,4 +73,8 @@ impl BridgeParse for LayerId {
 
 impl BridgeParse for SourceId {
   const KIND: &'static str = "source ID";
+}
+
+impl BridgeParse for LedgerEntryId {
+  const KIND: &'static str = "ledger entry ID";
 }

--- a/crates/shift-wire/src/bridges/napi/mod.rs
+++ b/crates/shift-wire/src/bridges/napi/mod.rs
@@ -1485,6 +1485,9 @@ pub struct NapiFontReplacement {
 /// Pure-state response to `apply`: no change records cross to the renderer.
 #[napi(object)]
 pub struct NapiAppliedChange {
+    /// Stable identity of the document ledger entry, absent for an empty apply.
+    #[napi(ts_type = "LedgerEntryId")]
+    pub ledger_entry_id: Option<String>,
     pub layers: Vec<NapiLayerReplaced>,
     /// Present when the apply produced any font-level replacement collections.
     pub next: Option<NapiFontReplacement>,

--- a/crates/shift-workspace/docs/DOCS.md
+++ b/crates/shift-workspace/docs/DOCS.md
@@ -1,6 +1,6 @@
 # shift-workspace
 
-<!-- reviewed: 2026-09-01 review-every: 90d -->
+<!-- reviewed: 2026-09-06 review-every: 90d -->
 
 Backend runtime object for an open Shift font workspace.
 

--- a/crates/shift-workspace/docs/DOCS.md
+++ b/crates/shift-workspace/docs/DOCS.md
@@ -23,7 +23,7 @@ Backend runtime object for an open Shift font workspace.
 - **Architecture Invariant:** Source and axis topology entries retain complete pre/post identity order. Replay restores entities first, then restores collection order and the source collection's default identity; SQLite persists the same dense order in that transaction.
 - **Architecture Invariant:** `LedgerStep::GlyphAppend` represents the only authored glyph-topology transition. Redo appends in application order and undo pops in reverse order; persistence materializes and rewrites only those tail rows, never the complete glyph directory.
 - **Architecture Invariant:** After every successful apply, undo, or redo, loading the merged durable store produces the live `Font`; a failed transition changes neither live state, durable state, nor ledger availability.
-- **Architecture Invariant:** Undo and redo retain at most 100 entries per stack. Extending either stack drops that stack's oldest entry; a fresh apply clears redo.
+- **Architecture Invariant:** Undo and redo retain at most 100 entries per stack. Extending either stack drops that stack's oldest entry; a fresh apply clears redo. Every entry has a stable process-local `LedgerEntryId`; identified replay rejects rather than popping a different next entry, and explicit redo discard changes no live or saved document position.
 - **Architecture Invariant:** Document `dirty` compares the ledger's current history position with its saved position; the durable authored revision remains monotonic and is not an undo cursor. Undo/redo persist their resulting dirty value atomically with replay. A resumed dirty workspace has no reachable saved position because its in-memory ledger does not survive process restart.
 
 ## Codemap
@@ -45,6 +45,7 @@ crates/shift-workspace/examples/
 ## Key Types
 
 - `FontWorkspace` -- live backend object for one open font project.
+- `LedgerEntryId` -- stable identity for one in-memory document history entry; valid only for the lifetime of the open workspace.
 - `NewWorkspace` -- options used when creating a new app-owned working database.
 - `DocumentIdentity` -- canonical `DocumentId` and canonical path for one native `.shift` document address.
 - `WorkspaceSource` -- explicit source state: untitled, native document, or imported external file.
@@ -114,7 +115,7 @@ observations rather than CI assertions.
 
 - `font()` reflects only what has been acquired. A glyph present in the directory but never acquired shows placeholder layers with no error — forgetting acquisition produces silently empty geometry, not a crash.
 - One `apply` call = one SQLite transaction = one undo step, even for multi-intent sets. Batching intents into a single `FontIntentSet` is the only way to get one undo step; there is no separate ledger grouping API.
-- A failed undo/redo replay pushes the entry back onto its stack instead of half-applying, so a replay error is retryable — but code that pops the ledger around `replay` must preserve that restore-on-error contract.
+- A failed undo/redo replay pushes the entry back onto its stack instead of half-applying, so a replay error is retryable — but code that pops the ledger around `replay` must preserve that restore-on-error contract. Identified replay checks the next entry before popping, allowing renderer-owned history to coordinate without duplicating document snapshots.
 - The undo and redo stacks each cap at 100 entries and drop the oldest silently. Tests that build long histories and then unwind them fully will pass at small sizes and lie at scale.
 - Dirty is a ledger-position comparison, not a revision comparison. After `resume`, a workspace that was dirty at shutdown has no reachable saved position: no amount of undo makes it report clean.
 - `evict_glyphs` performs no committed-state check — it drops any loaded layer back to a directory placeholder. Eviction is still safe because `apply`, undo, and redo persist every authored edit before swapping the live font, so an uncommitted loaded layer cannot exist. Code that mutates the live font without persisting first would break that guarantee and make eviction lose work.

--- a/crates/shift-workspace/src/ledger.rs
+++ b/crates/shift-workspace/src/ledger.rs
@@ -7,7 +7,7 @@
 //! a renderer reload (it lives with the workspace process), not a utility
 //! crash; a SQLite ledger table is the later upgrade if that ever matters.
 
-use std::sync::Arc;
+use std::{fmt, str::FromStr, sync::Arc};
 
 use shift_font::{
     Axis, AxisId, AxisMapping, FontMetadata, Glyph, GlyphId, GlyphLayer, GlyphName, LayerId,
@@ -18,8 +18,27 @@ use shift_font::{
 /// the stack being extended falls off first; a fresh apply also clears redo.
 const MAX_ENTRIES_PER_STACK: usize = 100;
 
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
-struct HistoryPosition(u64);
+/// Stable identity for one in-memory workspace ledger entry.
+///
+/// Identities remain valid for the lifetime of the open workspace. They let a
+/// renderer verify that a coordinated editor action replays the intended
+/// document entry without owning or duplicating its state pairs.
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
+pub struct LedgerEntryId(u64);
+
+impl fmt::Display for LedgerEntryId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(formatter)
+    }
+}
+
+impl FromStr for LedgerEntryId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse().map(Self)
+    }
+}
 
 #[derive(Clone)]
 pub enum LedgerStep {
@@ -106,7 +125,7 @@ pub struct LayerPair {
 
 #[derive(Clone)]
 pub struct LedgerEntry {
-    position: HistoryPosition,
+    pub id: LedgerEntryId,
     pub label: Option<String>,
     pub steps: Vec<LedgerStep>,
 }
@@ -146,8 +165,8 @@ impl LedgerEntry {
 pub struct Ledger {
     undo: Vec<LedgerEntry>,
     redo: Vec<LedgerEntry>,
-    base_position: HistoryPosition,
-    saved_position: Option<HistoryPosition>,
+    base_position: LedgerEntryId,
+    saved_position: Option<LedgerEntryId>,
     next_position: u64,
 }
 
@@ -162,22 +181,36 @@ impl Ledger {
         Self {
             undo: Vec::new(),
             redo: Vec::new(),
-            base_position: HistoryPosition::default(),
-            saved_position: (!dirty).then_some(HistoryPosition::default()),
+            base_position: LedgerEntryId::default(),
+            saved_position: (!dirty).then_some(LedgerEntryId::default()),
             next_position: 1,
         }
     }
 
     /// Records an applied entry. A fresh apply truncates the redo stack.
-    pub fn push(&mut self, label: Option<String>, steps: Vec<LedgerStep>) {
+    pub fn push(&mut self, label: Option<String>, steps: Vec<LedgerStep>) -> LedgerEntryId {
         self.redo.clear();
-        let entry = LedgerEntry {
-            position: HistoryPosition(self.next_position),
-            label,
-            steps,
-        };
+        let id = LedgerEntryId(self.next_position);
+        let entry = LedgerEntry { id, label, steps };
         self.next_position += 1;
         push_undo_bounded(&mut self.undo, entry, &mut self.base_position);
+        id
+    }
+
+    /// Returns the next document entry that ordinary undo would replay.
+    pub fn next_undo_id(&self) -> Option<LedgerEntryId> {
+        self.undo.last().map(|entry| entry.id)
+    }
+
+    /// Returns the next document entry that ordinary redo would replay.
+    pub fn next_redo_id(&self) -> Option<LedgerEntryId> {
+        self.redo.last().map(|entry| entry.id)
+    }
+
+    /// Permanently removes every currently undone entry without changing the
+    /// current or saved document positions.
+    pub fn discard_redo(&mut self) {
+        self.redo.clear();
     }
 
     /// Pops the entry to undo; the caller replays its pre states and must
@@ -222,24 +255,24 @@ impl Ledger {
     }
 
     pub fn is_entry_dirty(&self, entry: &LedgerEntry) -> bool {
-        self.saved_position != Some(entry.position)
+        self.saved_position != Some(entry.id)
     }
 
-    fn current_position(&self) -> HistoryPosition {
+    fn current_position(&self) -> LedgerEntryId {
         self.undo
             .last()
-            .map_or(self.base_position, |entry| entry.position)
+            .map_or(self.base_position, |entry| entry.id)
     }
 }
 
 fn push_undo_bounded(
     stack: &mut Vec<LedgerEntry>,
     entry: LedgerEntry,
-    base_position: &mut HistoryPosition,
+    base_position: &mut LedgerEntryId,
 ) {
     stack.push(entry);
     if stack.len() > MAX_ENTRIES_PER_STACK {
-        *base_position = stack.remove(0).position;
+        *base_position = stack.remove(0).id;
     }
 }
 
@@ -270,6 +303,39 @@ mod tests {
         ledger.record_undone(entry(MAX_ENTRIES_PER_STACK + 1));
         assert_eq!(ledger.redo.len(), MAX_ENTRIES_PER_STACK);
         assert_eq!(ledger.redo[0].label.as_deref(), Some("2"));
+    }
+
+    #[test]
+    fn entries_keep_stable_monotonic_identities_across_replay() {
+        let mut ledger = Ledger::default();
+        let first = ledger.push(Some("first".into()), Vec::new());
+        let second = ledger.push(Some("second".into()), Vec::new());
+
+        assert_ne!(first, second);
+        assert_eq!(ledger.next_undo_id(), Some(second));
+
+        let entry = ledger.pop_undo().unwrap();
+        ledger.record_undone(entry);
+        assert_eq!(ledger.next_redo_id(), Some(second));
+
+        let entry = ledger.pop_redo().unwrap();
+        ledger.record_redone(entry);
+        assert_eq!(ledger.next_undo_id(), Some(second));
+    }
+
+    #[test]
+    fn discard_redo_preserves_the_current_document_position() {
+        let mut ledger = Ledger::default();
+        ledger.push(Some("saved".into()), Vec::new());
+        ledger.mark_saved();
+        let entry = ledger.pop_undo().unwrap();
+        ledger.record_undone(entry);
+        assert!(ledger.is_dirty());
+
+        ledger.discard_redo();
+
+        assert!(ledger.is_dirty());
+        assert_eq!(ledger.next_redo_id(), None);
     }
 
     #[test]
@@ -311,7 +377,7 @@ mod tests {
 
     fn entry(index: usize) -> LedgerEntry {
         LedgerEntry {
-            position: HistoryPosition(index as u64),
+            id: LedgerEntryId(index as u64),
             label: Some(index.to_string()),
             steps: Vec::new(),
         }

--- a/crates/shift-workspace/src/lib.rs
+++ b/crates/shift-workspace/src/lib.rs
@@ -8,6 +8,6 @@ mod workspace;
 
 pub use document_identity::DocumentIdentity;
 pub use import_pipeline::{ImportBatchProgress, stream_into};
-pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerStep};
+pub use ledger::{LayerPair, Ledger, LedgerEntry, LedgerEntryId, LedgerStep};
 pub use new_workspace::NewWorkspace;
 pub use workspace::{AcquireScope, FontWorkspace, WorkspaceError, WorkspaceSource};

--- a/crates/shift-workspace/src/workspace.rs
+++ b/crates/shift-workspace/src/workspace.rs
@@ -21,7 +21,7 @@ use shift_store::{
 use crate::document_identity::{DocumentIdentity, document_identity};
 use crate::import_staging::{create_import_staging_path, install_import_store};
 use crate::layer_residency::LayerResidency;
-use crate::ledger::{GlyphIdentity, LayerPair, Ledger, LedgerEntry, LedgerStep};
+use crate::ledger::{GlyphIdentity, LayerPair, Ledger, LedgerEntry, LedgerEntryId, LedgerStep};
 use crate::{NewWorkspace, stream_into};
 
 #[derive(Debug, thiserror::Error)]
@@ -52,6 +52,13 @@ pub enum WorkspaceError {
 
     #[error("invalid UTF-8 in workspace path: {0}")]
     InvalidPathUtf8(PathBuf),
+
+    #[error("cannot {direction} ledger entry {expected}; next entry is {actual:?}")]
+    LedgerEntryMismatch {
+        direction: &'static str,
+        expected: LedgerEntryId,
+        actual: Option<LedgerEntryId>,
+    },
 
     #[error("workspace file-system error: {0}")]
     Io(#[from] io::Error),
@@ -243,15 +250,25 @@ impl FontWorkspace {
             .map_err(WorkspaceError::from)
     }
 
-    /// Applies a renderer intent set: validate + mutate via shift-font,
-    /// persist the canonical records, swap the live font, record one ledger
-    /// entry. One call = one SQLite transaction = one undo step — including
-    /// sets that batch several create intents.
+    /// Applies a renderer intent set as one persisted and undoable operation.
     pub fn apply(
         &mut self,
         set: FontIntentSet,
         label: Option<String>,
     ) -> Result<AppliedIntents, WorkspaceError> {
+        self.apply_with_entry_id(set, label)
+            .map(|(_, outcome)| outcome)
+    }
+
+    /// Applies one intent set and returns the stable identity of its ledger entry.
+    ///
+    /// One call performs one SQLite transaction and records one undo step,
+    /// including sets that batch several create intents.
+    pub fn apply_with_entry_id(
+        &mut self,
+        set: FontIntentSet,
+        label: Option<String>,
+    ) -> Result<(LedgerEntryId, AppliedIntents), WorkspaceError> {
         let required_layers = set
             .intents
             .iter()
@@ -286,8 +303,8 @@ impl FontWorkspace {
         })?;
 
         let steps = self.ledger_steps(&pre, &outcome);
-        self.ledger.push(label, steps);
-        Ok(outcome)
+        let entry_id = self.ledger.push(label, steps);
+        Ok((entry_id, outcome))
     }
 
     /// Derives the entry's state-pair steps from the applied change set,
@@ -509,11 +526,52 @@ impl FontWorkspace {
         steps
     }
 
+    /// Returns the stable identity of the entry ordinary undo would replay.
+    pub fn next_undo_entry_id(&self) -> Option<LedgerEntryId> {
+        self.ledger.next_undo_id()
+    }
+
+    /// Returns the stable identity of the entry ordinary redo would replay.
+    pub fn next_redo_entry_id(&self) -> Option<LedgerEntryId> {
+        self.ledger.next_redo_id()
+    }
+
     /// Replays the most recent entry's pre states in reverse step order.
     /// `None` when the undo stack is empty. The echo is the same
     /// replace-grade shape as `apply`. A failed replay hands the entry back
     /// so the step stays available for retry.
     pub fn undo(&mut self) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        self.undo_expected(None)
+    }
+
+    /// Replays `expected` only when it is the next ordinary undo entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkspaceError::LedgerEntryMismatch`] without changing either
+    /// stack when another entry is next.
+    pub fn undo_entry(
+        &mut self,
+        expected: LedgerEntryId,
+    ) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        self.undo_expected(Some(expected))
+    }
+
+    fn undo_expected(
+        &mut self,
+        expected: Option<LedgerEntryId>,
+    ) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        if let Some(expected) = expected {
+            let actual = self.ledger.next_undo_id();
+            if actual != Some(expected) {
+                return Err(WorkspaceError::LedgerEntryMismatch {
+                    direction: "undo",
+                    expected,
+                    actual,
+                });
+            }
+        }
+
         let Some(entry) = self.ledger.pop_undo() else {
             return Ok(None);
         };
@@ -535,6 +593,37 @@ impl FontWorkspace {
     /// A failed replay hands the entry back so the step stays available
     /// for retry.
     pub fn redo(&mut self) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        self.redo_expected(None)
+    }
+
+    /// Replays `expected` only when it is the next ordinary redo entry.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkspaceError::LedgerEntryMismatch`] without changing either
+    /// stack when another entry is next.
+    pub fn redo_entry(
+        &mut self,
+        expected: LedgerEntryId,
+    ) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        self.redo_expected(Some(expected))
+    }
+
+    fn redo_expected(
+        &mut self,
+        expected: Option<LedgerEntryId>,
+    ) -> Result<Option<AppliedIntents>, WorkspaceError> {
+        if let Some(expected) = expected {
+            let actual = self.ledger.next_redo_id();
+            if actual != Some(expected) {
+                return Err(WorkspaceError::LedgerEntryMismatch {
+                    direction: "redo",
+                    expected,
+                    actual,
+                });
+            }
+        }
+
         let Some(entry) = self.ledger.pop_redo() else {
             return Ok(None);
         };
@@ -550,6 +639,12 @@ impl FontWorkspace {
                 Err(error)
             }
         }
+    }
+
+    /// Permanently removes every redo entry without changing live font state
+    /// or the current/saved document positions.
+    pub fn discard_redo(&mut self) {
+        self.ledger.discard_redo();
     }
 
     fn replay(

--- a/crates/shift-workspace/tests/workspace_test.rs
+++ b/crates/shift-workspace/tests/workspace_test.rs
@@ -2357,6 +2357,45 @@ fn create_source_undo_redo_removes_and_restores_source() {
 }
 
 #[test]
+fn identified_replay_rejects_a_different_next_entry_without_mutation() {
+    let temp = tempfile::tempdir().unwrap();
+    let store_path = temp.path().join("working.sqlite");
+    let mut workspace = FontWorkspace::create_untitled(&store_path, NewWorkspace::new()).unwrap();
+    let (first_id, _) = workspace
+        .apply_with_entry_id(
+            FontIntentSet {
+                intents: vec![create_glyph_intent("A", vec![65])],
+            },
+            None,
+        )
+        .unwrap();
+    let (second_id, _) = workspace
+        .apply_with_entry_id(
+            FontIntentSet {
+                intents: vec![create_glyph_intent("B", vec![66])],
+            },
+            None,
+        )
+        .unwrap();
+
+    let error = match workspace.undo_entry(first_id) {
+        Ok(_) => panic!("identified undo should reject a different next entry"),
+        Err(error) => error,
+    };
+
+    assert!(matches!(
+        error,
+        WorkspaceError::LedgerEntryMismatch {
+            direction: "undo",
+            expected,
+            actual: Some(actual),
+        } if expected == first_id && actual == second_id
+    ));
+    assert_eq!(workspace.font().glyph_count(), 2);
+    assert_eq!(workspace.next_undo_entry_id(), Some(second_id));
+}
+
+#[test]
 fn failed_undo_replay_hands_the_entry_back_for_retry() {
     let temp = tempfile::tempdir().unwrap();
     let store_path = temp.path().join("working.sqlite");

--- a/packages/types/docs/DOCS.md
+++ b/packages/types/docs/DOCS.md
@@ -1,6 +1,6 @@
 # @shift/types
 
-<!-- reviewed: 2026-08-19 review-every: 90d -->
+<!-- reviewed: 2026-09-06 review-every: 90d -->
 
 Shared DTO TypeScript types for Shift. This package owns branded IDs and bridge DTOs generated from `shift-bridge`.
 
@@ -9,7 +9,7 @@ Shared DTO TypeScript types for Shift. This package owns branded IDs and bridge 
 - **Architecture Invariant: CRITICAL:** `src/bridge/generated.ts` is generated from `crates/shift-bridge/index.d.ts` by `scripts/generate-bridge-types.mjs`. Never edit it manually.
 - **Architecture Invariant: CRITICAL:** `@shift/types` is the canonical TypeScript DTO facade for the native bridge. It strips `Napi*` prefixes and exports type-only DTOs.
 - **Architecture Invariant:** Editor-owned state types (selection, tools, camera, command history, renderer snapshots) do not live here. `src/domain.ts` holds only small derived domain shapes built from bridge DTOs: `AxisDefinition` and `NamedInstanceDefinition` (definitions before the editor assigns stable identity) and resolved `SourceMetrics`.
-- **Architecture Invariant:** Entity IDs are branded string types. TypeScript mints IDs for synchronous create intents where the renderer must know identity immediately (for example `GlyphId`, `AxisId`, `AxisLabelId`, `AxisMappingId`, `NamedInstanceId`, and point/contour/anchor IDs); Rust validates and honors those IDs. Use `as*Id()` helpers to cast raw bridge strings into branded types. Compiled variation contributions never fabricate entity IDs.
+- **Architecture Invariant:** Entity IDs are branded string types. TypeScript mints IDs for synchronous create intents where the renderer must know identity immediately (for example `GlyphId`, `AxisId`, `AxisLabelId`, `AxisMappingId`, `NamedInstanceId`, and point/contour/anchor IDs); Rust validates and honors those IDs. Use `as*Id()` helpers to cast raw bridge strings into branded types. Compiled variation contributions never fabricate entity IDs. `LedgerEntryId` is different: Rust mints this process-local history identity and TypeScript may only transport it back for identified replay.
 - **Architecture Invariant:** This package ships raw `.ts` source. `package.json` points `main` and `types` directly at `src/index.ts`.
 
 ## Codemap
@@ -39,7 +39,8 @@ Import from `@shift/types`.
 - `AxisMappingBasis` -- mapping identity and ordered input/output axes plus a compiled normalized-adjustment basis.
 - `GlyphVariation` -- imported fallback-relative numeric variation without fabricated authored source identities.
 - `GlyphProjection` -- location-independent renderer backing with fallback shape, optional authored interpolation or imported variation, exact-source shapes, and component identities.
-- `AppliedChange` -- replace-grade mutation response returned by apply/undo/redo; its optional `next.metadata` is a complete replacement.
+- `AppliedChange` -- replace-grade mutation response returned by apply/undo/redo; `ledgerEntryId` identifies the Rust history entry and optional `next.metadata` is a complete replacement.
+- `LedgerEntryId` -- branded process-local identity for one Rust document ledger entry; it is not authored font identity or durable document state.
 - `Axis` / `AxisMapping` / `NamedInstance` -- generated variation authoring DTOs, keyed by branded entity IDs and expressed in Shift coordinate spaces.
 - `SourceMetricsInterpolationSnapshot` -- derived metric schema, reusable interpolation basis, and ordered source values; it is workspace transport state, not an authored source or named instance.
 - `LayerReplaced` -- one replaced glyph layer in an applied change.

--- a/packages/types/src/bridge/generated.ts
+++ b/packages/types/src/bridge/generated.ts
@@ -9,6 +9,7 @@ import type {
   GuidelineId,
   GlyphId,
   LayerId,
+  LedgerEntryId,
   MetricId,
   NamedInstanceId,
   SourceId,
@@ -61,11 +62,17 @@ export interface BridgeApi {
    * undo stack is empty.
    */
   undo(): AppliedChange | null
+  /** Replays one identified entry only when it is next in the undo stack. */
+  undoEntry(entryId: LedgerEntryId): AppliedChange | null
   /**
    * Replays the most recent undone entry's post states; `null` when the
    * redo stack is empty.
    */
   redo(): AppliedChange | null
+  /** Replays one identified entry only when it is next in the redo stack. */
+  redoEntry(entryId: LedgerEntryId): AppliedChange | null
+  /** Permanently removes every currently undone document entry. */
+  discardRedo(): void
   /** Glyph-addressed snapshots for renderer-local synchronous font state. */
   getGlyphSnapshots(requests: Array<GlyphSnapshotRequest>): Array<GlyphSnapshot>
   /**
@@ -204,6 +211,8 @@ export interface AnchorSeed {
 
 /** Pure-state response to `apply`: no change records cross to the renderer. */
 export interface AppliedChange {
+  /** Stable identity of the document ledger entry, absent for an empty apply. */
+  ledgerEntryId?: LedgerEntryId
   layers: Array<LayerReplaced>
   /** Present when the apply produced any font-level replacement collections. */
   next?: FontReplacement

--- a/packages/types/src/ids.ts
+++ b/packages/types/src/ids.ts
@@ -19,6 +19,7 @@ declare const ComponentIdBrand: unique symbol;
 declare const GuidelineIdBrand: unique symbol;
 declare const GlyphIdBrand: unique symbol;
 declare const LayerIdBrand: unique symbol;
+declare const LedgerEntryIdBrand: unique symbol;
 declare const MetricIdBrand: unique symbol;
 declare const NamedInstanceIdBrand: unique symbol;
 declare const NodeIdBrand: unique symbol;
@@ -90,6 +91,11 @@ export type GlyphId = string & { readonly [GlyphIdBrand]: typeof GlyphIdBrand };
  * Branded string type - can't be confused with other IDs or plain strings.
  */
 export type LayerId = string & { readonly [LayerIdBrand]: typeof LayerIdBrand };
+
+/** Stable identity of one entry in an open workspace's document ledger. */
+export type LedgerEntryId = string & {
+  readonly [LedgerEntryIdBrand]: typeof LedgerEntryIdBrand;
+};
 
 /** Stable identity of one font-owned metric definition. */
 export type MetricId = string & { readonly [MetricIdBrand]: typeof MetricIdBrand };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -14,6 +14,7 @@ export type {
   GuidelineId,
   GlyphId,
   LayerId,
+  LedgerEntryId,
   MetricId,
   NamedInstanceId,
   NodeId,

--- a/scripts/generate-bridge-types.mjs
+++ b/scripts/generate-bridge-types.mjs
@@ -27,6 +27,7 @@ const idTypeNames = new Set([
   "AxisMappingId",
   "ComponentId",
   "GuidelineId",
+  "LedgerEntryId",
   "SourceId",
   "NamedInstanceId",
 ]);


### PR DESCRIPTION
## Summary

- assign stable process-local identities to Rust document-ledger entries
- expose identified undo/redo that rejects before replaying a different next entry
- expose redo-branch discard without changing font state, dirty state, or saved position
- transport ledger identities through the generated bridge and workspace channel

## Stack

Base for #368.

## Issue

Refs #366

## Testing

Passed:

- `cargo test -p shift-workspace`
- `cargo clippy -p shift-workspace -p shift-bridge --all-targets -- -D warnings`
- `pnpm test:native`
- `pnpm test:desktop src/utility/workspace/WorkspaceHost.test.ts`
- `pnpm test:desktop src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts`
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `python3 scripts/check-invariants.py`
- `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo doc -p shift-workspace -p shift-bridge --no-deps --document-private-items`

Not used as evidence:

- `cargo test -p shift-bridge` cannot link standalone N-API tests without Node's N-API symbols; the canonical `pnpm test:native` bridge suite passed.
- `python3 scripts/context-drift-check.py` completed link checks but reported 9 pre-existing review-date warnings in unrelated documentation.
