### PR TITLE
feat(editor): make selection history undoable

### DIFF
--- a/apps/desktop/e2e/deletion.spec.ts
+++ b/apps/desktop/e2e/deletion.spec.ts
@@ -153,8 +153,12 @@ test("Delete fits a selected point and undo/redo restores the exact outline", as
   });
   await page.keyboard.press("ControlOrMeta+z");
   await expect.poll(() => outline(page)).toEqual(before);
+  await expect
+    .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+    .toEqual([selected.id]);
   await page.keyboard.press("ControlOrMeta+Shift+z");
   await expect.poll(() => outline(page)).toEqual(after);
+  await expect.poll(() => page.evaluate(() => window.shift?.editor.selection.ids)).toEqual([]);
 });
 
 test("Delete joins corner endpoints as a line without creating handles", async ({

--- a/apps/desktop/e2e/marquee-selection.spec.ts
+++ b/apps/desktop/e2e/marquee-selection.spec.ts
@@ -1,0 +1,182 @@
+import type { Page } from "@playwright/test";
+import type { Point2D } from "@shift/geo";
+import { documentWorkspaceTest as test, expect } from "./fixtures/electronApp";
+import { openGlyphRoute } from "./fixtures/appLocators";
+
+async function pointTargets(page: Page) {
+  return page.evaluate(() => {
+    const editor = window.shift?.editor;
+    const node = editor?.scene.nodesOfKind("glyph")[0];
+    const layer = node ? editor?.glyphForId(node.glyphId)?.layerForSource(node.sourceId) : null;
+    if (!editor || !node || !layer) throw new Error("Expected authored glyph outline");
+
+    return layer.allPoints.map((point) => ({
+      id: point.id,
+      pointType: point.pointType,
+      screen: editor.projectSceneToScreen({
+        x: point.x + node.position.x,
+        y: point.y + node.position.y,
+      }),
+    }));
+  });
+}
+
+async function hasBlueStroke(page: Page, canvasId: string, point: Point2D): Promise<boolean> {
+  return page.locator(`#${canvasId}`).evaluate(async (element, point) => {
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+    );
+    const context = (element as HTMLCanvasElement).getContext("2d");
+    if (!context) throw new Error("Expected 2D canvas context");
+    const pixels = context.getImageData(
+      Math.round(point.x) - 2,
+      Math.round(point.y) - 2,
+      5,
+      5,
+    ).data;
+    for (let index = 0; index < pixels.length; index += 4) {
+      if (
+        pixels[index + 3]! > 0 &&
+        pixels[index + 2]! > pixels[index]! + 40 &&
+        pixels[index + 1]! > pixels[index]! + 20
+      )
+        return true;
+    }
+    return false;
+  }, point);
+}
+
+test.beforeEach(async ({ page }) => {
+  const glyphId = await page.evaluate(
+    () => window.shift?.font.glyphRecords().find((glyph) => glyph.name === "I")?.id,
+  );
+  if (!glyphId) throw new Error("Expected I glyph");
+  await openGlyphRoute(page, glyphId);
+  await page.getByRole("button", { name: "Select Tool (V)" }).click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Backspace");
+  await expect.poll(() => pointTargets(page)).toEqual([]);
+
+  const canvas = page.locator("#interactive-canvas");
+  const bounds = await canvas.boundingBox();
+  if (!bounds) throw new Error("Expected interactive canvas bounds");
+  await page.getByRole("button", { name: "Pen Tool (P)" }).click();
+  await canvas.click({ position: { x: bounds.width * 0.3, y: bounds.height * 0.7 } });
+  await canvas.click({ position: { x: bounds.width * 0.45, y: bounds.height * 0.45 } });
+  await canvas.click({ position: { x: bounds.width * 0.7, y: bounds.height * 0.3 } });
+  await page.getByRole("button", { name: "Select Tool (V)" }).click();
+  await expect.poll(async () => (await pointTargets(page)).length).toBe(3);
+});
+
+test("Shift-marquee preserves segment highlights and freezes the old box until release", async ({
+  page,
+}, testInfo) => {
+  const [first, second, third] = await pointTargets(page);
+  if (!first || !second || !third) throw new Error("Expected three points");
+  const canvas = page.locator("#interactive-canvas");
+  const bounds = await canvas.boundingBox();
+  if (!bounds) throw new Error("Expected interactive canvas bounds");
+
+  await page.mouse.move(bounds.x + first.screen.x - 20, bounds.y + second.screen.y - 20);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + second.screen.x + 20, bounds.y + first.screen.y + 20, {
+    steps: 5,
+  });
+  await page.mouse.up();
+  await expect
+    .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+    .toEqual([first.id, second.id]);
+
+  const segment = {
+    x: (first.screen.x + second.screen.x) / 2,
+    y: (first.screen.y + second.screen.y) / 2,
+  };
+  const oldBox = { x: second.screen.x, y: segment.y };
+  const newBox = { x: third.screen.x, y: (first.screen.y + third.screen.y) / 2 };
+  await page.keyboard.down("Shift");
+  await page.mouse.move(bounds.x + third.screen.x - 18, bounds.y + third.screen.y - 18);
+
+  for (const stage of ["before", "pressed", "dragging", "released"]) {
+    switch (stage) {
+      case "pressed":
+        await page.mouse.down();
+        break;
+      case "dragging":
+        await page.mouse.move(bounds.x + third.screen.x + 18, bounds.y + third.screen.y + 18, {
+          steps: 5,
+        });
+        await expect
+          .poll(() => page.evaluate(() => window.shift?.editor.toolCell.peek()?.state.type))
+          .toBe("brushing");
+        break;
+      case "released":
+        await page.mouse.up();
+        break;
+    }
+
+    await expect
+      .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+      .toEqual(
+        stage === "dragging" || stage === "released"
+          ? [first.id, second.id, third.id]
+          : [first.id, second.id],
+      );
+    const highlighted = await hasBlueStroke(page, "scene-canvas", segment);
+    const oldBoxVisible = await hasBlueStroke(page, "interactive-canvas", oldBox);
+    const newBoxVisible = await hasBlueStroke(page, "interactive-canvas", newBox);
+    await page.screenshot({ path: testInfo.outputPath(`shift-marquee-${stage}.png`) });
+    await testInfo.attach(`shift-marquee-${stage}`, {
+      path: testInfo.outputPath(`shift-marquee-${stage}.png`),
+      contentType: "image/png",
+    });
+    expect(highlighted, `selected segment at ${stage}`).toBe(true);
+    expect(oldBoxVisible, `old selection box at ${stage}`).toBe(stage !== "released");
+    expect(newBoxVisible, `combined selection box at ${stage}`).toBe(stage === "released");
+  }
+  await page.keyboard.up("Shift");
+});
+
+test("a partially selected line stays unhighlighted until both endpoints are selected", async ({
+  page,
+}) => {
+  const [first, second] = await pointTargets(page);
+  if (!first || !second) throw new Error("Expected line endpoints");
+  const canvas = page.locator("#interactive-canvas");
+  const segment = {
+    x: (first.screen.x + second.screen.x) / 2,
+    y: (first.screen.y + second.screen.y) / 2,
+  };
+
+  await canvas.click({ position: first.screen });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(false);
+  await canvas.click({ position: second.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(true);
+  await canvas.click({ position: first.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(false);
+});
+
+test("a cubic is highlighted only when its controls and endpoints are selected", async ({
+  page,
+}) => {
+  const [first, second] = await pointTargets(page);
+  if (!first || !second) throw new Error("Expected line endpoints");
+  const canvas = page.locator("#interactive-canvas");
+  const segment = {
+    x: (first.screen.x + second.screen.x) / 2,
+    y: (first.screen.y + second.screen.y) / 2,
+  };
+  await canvas.click({ position: segment, modifiers: ["Alt"] });
+  await expect.poll(async () => (await pointTargets(page)).length).toBe(5);
+  const controls = (await pointTargets(page)).filter((point) => point.pointType === "offCurve");
+  expect(controls).toHaveLength(2);
+
+  await canvas.click({ position: first.screen });
+  await canvas.click({ position: second.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(false);
+  await canvas.click({ position: controls[0]!.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(false);
+  await canvas.click({ position: controls[1]!.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(true);
+  await canvas.click({ position: controls[0]!.screen, modifiers: ["Shift"] });
+  expect(await hasBlueStroke(page, "scene-canvas", segment)).toBe(false);
+});

--- a/apps/desktop/e2e/selection-history.spec.ts
+++ b/apps/desktop/e2e/selection-history.spec.ts
@@ -1,0 +1,134 @@
+import type { Page } from "@playwright/test";
+import { documentWorkspaceTest as test, expect } from "./fixtures/electronApp";
+import { openGlyphRoute } from "./fixtures/appLocators";
+
+async function pointTargets(page: Page) {
+  return page.evaluate(() => {
+    const editor = window.shift?.editor;
+    const node = editor?.scene.nodesOfKind("glyph")[0];
+    const layer = node ? editor?.glyphForId(node.glyphId)?.layerForSource(node.sourceId) : null;
+    if (!editor || !node || !layer) throw new Error("Expected authored glyph outline");
+
+    return layer.allPoints
+      .filter((point) => point.pointType === "onCurve")
+      .slice(0, 2)
+      .map((point) => ({
+        id: point.id,
+        position: { x: point.x, y: point.y },
+        screen: editor.projectSceneToScreen({
+          x: point.x + node.position.x,
+          y: point.y + node.position.y,
+        }),
+      }));
+  });
+}
+
+async function pointAndSelection(page: Page, pointId: string) {
+  return page.evaluate(async (id) => {
+    const editor = window.shift?.editor;
+    if (!editor) throw new Error("Expected editor");
+    await editor.font.editCoordinator.settled();
+
+    const node = editor.scene.nodesOfKind("glyph")[0];
+    const layer = node ? editor.glyphForId(node.glyphId)?.layerForSource(node.sourceId) : null;
+    const point = layer?.allPoints.find((candidate) => candidate.id === id);
+    if (!point) throw new Error("Expected editable point");
+
+    return {
+      point: { x: point.x, y: point.y },
+      selection: editor.selection.ids,
+    };
+  }, pointId);
+}
+
+test.beforeEach(async ({ page }) => {
+  const glyphId = await page.evaluate(
+    () => window.shift?.font.glyphRecords().find((glyph) => glyph.name === "I")?.id,
+  );
+  if (!glyphId) throw new Error("Expected I glyph");
+
+  await openGlyphRoute(page, glyphId);
+  await page.getByRole("button", { name: "Select Tool (V)" }).click();
+});
+
+test("Shift-click selection is undoable and redoable", async ({ page }, testInfo) => {
+  const [first, second] = await pointTargets(page);
+  if (!first || !second) throw new Error("Expected two on-curve points");
+  const canvas = page.locator("#interactive-canvas");
+
+  await canvas.click({ position: first.screen });
+  await canvas.click({ position: second.screen, modifiers: ["Shift"] });
+  await expect
+    .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+    .toEqual([first.id, second.id]);
+  await page.screenshot({ path: testInfo.outputPath("shift-click-selected.png") });
+  await testInfo.attach("shift-click-selected", {
+    path: testInfo.outputPath("shift-click-selected.png"),
+    contentType: "image/png",
+  });
+
+  await page.keyboard.press("ControlOrMeta+z");
+  await expect
+    .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+    .toEqual([first.id]);
+  await page.screenshot({ path: testInfo.outputPath("shift-click-undone.png") });
+  await testInfo.attach("shift-click-undone", {
+    path: testInfo.outputPath("shift-click-undone.png"),
+    contentType: "image/png",
+  });
+
+  await page.keyboard.press("ControlOrMeta+Shift+z");
+  await expect
+    .poll(() => page.evaluate(() => window.shift?.editor.selection.ids))
+    .toEqual([first.id, second.id]);
+});
+
+test("selecting and dragging one point is one history action", async ({ page }, testInfo) => {
+  const [target] = await pointTargets(page);
+  if (!target) throw new Error("Expected an on-curve point");
+  const canvas = page.locator("#interactive-canvas");
+  const bounds = await canvas.boundingBox();
+  if (!bounds) throw new Error("Expected interactive canvas bounds");
+  await page.screenshot({ path: testInfo.outputPath("before-select-and-drag.png") });
+  await testInfo.attach("before-select-and-drag", {
+    path: testInfo.outputPath("before-select-and-drag.png"),
+    contentType: "image/png",
+  });
+
+  await page.mouse.move(bounds.x + target.screen.x, bounds.y + target.screen.y);
+  await page.mouse.down();
+  await page.mouse.move(bounds.x + target.screen.x + 30, bounds.y + target.screen.y + 20, {
+    steps: 5,
+  });
+  await page.mouse.up();
+
+  const moved = await pointAndSelection(page, target.id);
+  expect(moved.point).not.toEqual(target.position);
+  expect(moved.selection).toEqual([target.id]);
+  await page.screenshot({ path: testInfo.outputPath("selected-and-dragged.png") });
+  await testInfo.attach("selected-and-dragged", {
+    path: testInfo.outputPath("selected-and-dragged.png"),
+    contentType: "image/png",
+  });
+
+  await page.keyboard.press("ControlOrMeta+z");
+  await expect
+    .poll(() => pointAndSelection(page, target.id))
+    .toEqual({
+      point: target.position,
+      selection: [],
+    });
+  await page.screenshot({ path: testInfo.outputPath("selected-and-dragged-undone.png") });
+  await testInfo.attach("selected-and-dragged-undone", {
+    path: testInfo.outputPath("selected-and-dragged-undone.png"),
+    contentType: "image/png",
+  });
+
+  await page.keyboard.press("ControlOrMeta+Shift+z");
+  await expect.poll(() => pointAndSelection(page, target.id)).toEqual(moved);
+  await page.screenshot({ path: testInfo.outputPath("selected-and-dragged-redone.png") });
+  await testInfo.attach("selected-and-dragged-redone", {
+    path: testInfo.outputPath("selected-and-dragged-redone.png"),
+    contentType: "image/png",
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/commands/rendererCommands.test.ts
+++ b/apps/desktop/src/renderer/src/lib/commands/rendererCommands.test.ts
@@ -51,10 +51,20 @@ describe("empty and invalid editor operations", () => {
       { x: 100, y: 0 },
     ]);
     editor.selectAll();
+    const originalSelection = editor.selection.ids;
 
     expect(await runRendererCommand(editor, "edit.duplicate")).toBe(true);
     expect(editor.pointCount).toBe(4);
-    expect(editor.selection.ids).toHaveLength(2);
+    const duplicateSelection = editor.selection.ids;
+    expect(duplicateSelection).toHaveLength(2);
+
+    await editor.undo();
+    expect(editor.pointCount).toBe(2);
+    expect(editor.selection.ids).toEqual(originalSelection);
+    await editor.redo();
+    expect(editor.pointCount).toBe(4);
+    expect(editor.selection.ids).toEqual(duplicateSelection);
+
     expect(await runRendererCommand(editor, "edit.deselect")).toBe(true);
     expect(editor.selection.ids).toEqual([]);
   });

--- a/apps/desktop/src/renderer/src/lib/commands/rendererCommands.ts
+++ b/apps/desktop/src/renderer/src/lib/commands/rendererCommands.ts
@@ -54,10 +54,21 @@ export async function runRendererCommand(editor: Editor, id: EditorCommandId): P
       return editor.deleteSelection();
 
     case "edit.duplicate": {
-      const inserted = editor.duplicateSelection();
-      if (inserted.length === 0) return false;
+      const capture = editor.history.beginCapture();
+      try {
+        const inserted = editor.duplicateSelection();
+        if (inserted.length === 0) {
+          capture.discard();
+          return false;
+        }
 
-      editor.selection.select(inserted);
+        editor.selection.select(inserted);
+        capture.finish();
+      } catch (error) {
+        capture.discard();
+        throw error;
+      }
+
       await editor.font.editCoordinator.settled();
       return true;
     }

--- a/apps/desktop/src/renderer/src/lib/editor/BooleanOperations.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/BooleanOperations.test.ts
@@ -60,13 +60,16 @@ describe("editor boolean operations", () => {
       await editor.boolean(contourIdA, contourIdB, operation);
       const layer = editor.requireGlyphLayer();
       expectGeometry(layer, contourCount, area, bounds);
-      expect(editor.selection.ids).toEqual(layer.contours.map((contour) => contour.id));
+      const resultSelection = layer.contours.map((contour) => contour.id);
+      expect(editor.selection.ids).toEqual(resultSelection);
 
       await editor.undo();
       expectGeometry(editor.requireGlyphLayer(), 2, 16_200, [10, 10, 150, 150]);
+      expect(editor.selection.ids).toEqual([contourIdA, contourIdB]);
 
       await editor.redo();
       expectGeometry(editor.requireGlyphLayer(), contourCount, area, bounds);
+      expect(editor.selection.ids).toEqual(resultSelection);
     },
   );
 
@@ -105,7 +108,12 @@ describe("editor boolean operations", () => {
     expect(editor.selection.ids).toEqual([contourIdA, contourIdB]);
 
     await editor.undo();
+    expect(geometrySummary(layer)).toEqual(before);
+    expect(editor.selection.ids).toEqual([contourIdB]);
+
+    await editor.undo();
     expectGeometry(layer, 1, 8_100, [10, 10, 100, 100]);
+    expect(editor.selection.ids).toEqual([contourIdA]);
   });
 });
 

--- a/apps/desktop/src/renderer/src/lib/editor/ClipboardOperations.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/ClipboardOperations.test.ts
@@ -38,15 +38,19 @@ describe("editor clipboard operations", () => {
     await editor.copy();
 
     await editor.paste();
+    const firstPasteSelection = editor.selection.ids;
     await editor.paste();
+    const secondPasteSelection = editor.selection.ids;
 
     expect(contourShape(layer.contours[1]!)).toEqual(offsetContour(source, 20, -20));
     expect(contourShape(layer.contours[2]!)).toEqual(offsetContour(source, 40, -40));
 
     await editor.undo();
     expect(layer.contours).toHaveLength(2);
+    expect(editor.selection.ids).toEqual(firstPasteSelection);
     await editor.redo();
     expect(contourShape(layer.contours[2]!)).toEqual(offsetContour(source, 40, -40));
+    expect(editor.selection.ids).toEqual(secondPasteSelection);
   });
 
   it("cuts and pastes with separate undoable workspace edits", async () => {
@@ -61,17 +65,22 @@ describe("editor clipboard operations", () => {
 
     expect(await editor.paste()).toBe(true);
     expect(contourShape(layer.contours[0]!)).toEqual(pasted);
+    const pastedSelection = editor.selection.ids;
 
     await editor.undo();
     expect(layer.contours).toHaveLength(0);
+    expect(editor.selection.ids).toEqual([]);
     await editor.undo();
     expect(layer.contours[0]?.id).toBe(source.id);
     expect(contourShape(layer.contours[0]!)).toEqual(original);
+    expect(editor.selection.ids).toEqual([source.id]);
 
     await editor.redo();
     expect(layer.contours).toHaveLength(0);
+    expect(editor.selection.ids).toEqual([]);
     await editor.redo();
     expect(contourShape(layer.contours[0]!)).toEqual(pasted);
+    expect(editor.selection.ids).toEqual(pastedSelection);
   });
 
   it("pastes copied geometry into another glyph without changing the source", async () => {

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -53,6 +53,7 @@ import type { CameraTransform } from "./managers";
 import type { DebugOverlays } from "@/types/uiState";
 import type { TemporaryToolOptions } from "@/types/editor";
 import { Editing } from "./Editing";
+import { EditorHistory } from "./EditorHistory";
 import { Selection } from "./Selection";
 import type { Font } from "../model/Font";
 import type { FontStore } from "../model/FontStore";
@@ -138,6 +139,7 @@ export class Editor {
    * Glyph objects for ID-based scene nodes.
    */
   readonly selection: Selection;
+  readonly history: EditorHistory;
   readonly editing: Editing;
   readonly hover: Hover;
   readonly font: Font;
@@ -242,6 +244,10 @@ export class Editor {
     };
 
     this.selection = new Selection(this.#store);
+    this.history = new EditorHistory(
+      this.selection,
+      this.sessionMode === "authored" ? this.font.editCoordinator : null,
+    );
     this.editing = new Editing(this.#store);
     this.hover = new Hover();
     this.#selectionBounds = computed(
@@ -1062,12 +1068,11 @@ export class Editor {
   }
 
   public async undo(): Promise<void> {
-    // One undo authority: the workspace ledger (state-pair replay).
-    await this.font.editCoordinator.undo();
+    await this.history.undo();
   }
 
   public async redo(): Promise<void> {
-    await this.font.editCoordinator.redo();
+    await this.history.redo();
   }
 
   /**
@@ -1407,12 +1412,19 @@ export class Editor {
     const written = await this.#clipboard.write(content);
     if (!written) return false;
 
-    this.transaction("Cut", () => {
-      selection.layer.removePoints(pointIds);
-    });
-    this.selection.clear();
-    await this.font.editCoordinator.settled();
+    const capture = this.history.beginCapture();
+    try {
+      this.transaction("Cut", () => {
+        selection.layer.removePoints(pointIds);
+      });
+      this.selection.clear();
+      capture.finish();
+    } catch (error) {
+      capture.discard();
+      throw error;
+    }
 
+    await this.font.editCoordinator.settled();
     return true;
   }
 
@@ -1423,12 +1435,22 @@ export class Editor {
       return false;
     }
 
-    if (!selection.layer.deletePoints(pointIds, mode)) return false;
+    const capture = this.history.beginCapture();
+    try {
+      if (!selection.layer.deletePoints(pointIds, mode)) {
+        capture.discard();
+        return false;
+      }
 
-    this.selection.clear();
-    this.hover.clear();
+      this.selection.clear();
+      this.hover.clear();
+      capture.finish();
+    } catch (error) {
+      capture.discard();
+      throw error;
+    }
+
     await this.font.editCoordinator.settled();
-
     return true;
   }
 
@@ -1442,13 +1464,24 @@ export class Editor {
 
     switch (result.kind) {
       case "content": {
-        const inserted = this.insertContent(result.content, {
-          offset: this.#clipboard.nextPasteOffset(),
-        });
-        if (!inserted) return false;
+        const capture = this.history.beginCapture();
+        try {
+          const inserted = this.insertContent(result.content, {
+            offset: this.#clipboard.nextPasteOffset(),
+          });
+          if (!inserted) {
+            capture.discard();
+            return false;
+          }
 
-        this.selection.select(inserted);
-        this.setActiveTool("select");
+          this.selection.select(inserted);
+          this.setActiveTool("select");
+          capture.finish();
+        } catch (error) {
+          capture.discard();
+          throw error;
+        }
+
         await this.font.editCoordinator.settled();
         return true;
       }
@@ -1483,14 +1516,21 @@ export class Editor {
     const layer = this.#fontStore.glyphForId(node.glyphId)?.layerForSource(sourceId);
     if (!layer || !layer.contour(contourIdA) || !layer.contour(contourIdB)) return;
 
-    const previousContourIds = new Set(layer.contours.map((contour) => contour.id));
-    layer.applyBooleanOp(contourIdA, contourIdB, operation);
-    await this.font.editCoordinator.settled();
+    const capture = this.history.beginCapture();
+    try {
+      const previousContourIds = new Set(layer.contours.map((contour) => contour.id));
+      layer.applyBooleanOp(contourIdA, contourIdB, operation);
+      await this.font.editCoordinator.settled();
 
-    const resultContourIds = layer.contours
-      .filter((contour) => !previousContourIds.has(contour.id))
-      .map((contour) => contour.id);
-    this.selection.select(resultContourIds);
+      const resultContourIds = layer.contours
+        .filter((contour) => !previousContourIds.has(contour.id))
+        .map((contour) => contour.id);
+      this.selection.select(resultContourIds);
+      capture.finish();
+    } catch (error) {
+      capture.discard();
+      throw error;
+    }
   }
 
   public duplicateSelection(): PointId[] {
@@ -1509,6 +1549,7 @@ export class Editor {
     this.#cameraMetricsEffect.dispose();
     this.#renderer.destroy();
     this.#toolManager.dispose();
+    this.history.dispose();
     this.#handlesCell.set(new Map());
     this.#events.dispose();
   }

--- a/apps/desktop/src/renderer/src/lib/editor/Editor.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Editor.ts
@@ -788,19 +788,20 @@ export class Editor {
   }
 
   /**
-   * Returns the current selection bounds in scene coordinates.
+   * Returns scene-space bounds for selected object identities.
    *
    * @remarks
    * Selection stores IDs only. This method resolves those IDs against the
    * current scene and font, asks each object for its live bounds, and returns a
    * fresh axis-aligned rectangle enclosing the resolved objects.
    *
-   * @returns null when nothing is selected or no selected object has bounds.
+   * @param ids - Identities to bound, defaulting to the current selection; does not change selection.
+   * @returns null when no supplied object has bounds.
    */
-  public selectionBounds(): Rect2D | null {
+  public selectionBounds(ids: readonly SelectableId[] = this.selection.ids): Rect2D | null {
     let bounds: BoundsType | null = null;
 
-    for (const id of this.selection.ids) {
+    for (const id of ids) {
       const object = this.object(id);
       if (!object) continue;
 

--- a/apps/desktop/src/renderer/src/lib/editor/EditorHistory.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/EditorHistory.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import type { PointId } from "@shift/types";
+import { TestEditor } from "@/testing/TestEditor";
+
+describe("editor history", () => {
+  let editor: TestEditor;
+  let firstId: PointId;
+  let secondId: PointId;
+
+  beforeEach(async () => {
+    editor = new TestEditor();
+    await editor.startSession();
+    const pointIds = await editor.drawOpenContour([
+      { x: 100, y: 100 },
+      { x: 200, y: 200 },
+    ]);
+    if (!pointIds[0] || !pointIds[1]) throw new Error("Expected two points");
+    [firstId, secondId] = pointIds;
+    editor.selectTool("select");
+    editor.history.reset();
+  });
+
+  it("does not change document state for selection-only history", async () => {
+    const before = await editor.font.editCoordinator.state();
+
+    editor.selection.select([firstId]);
+    await editor.undo();
+    await editor.redo();
+
+    expect(await editor.font.editCoordinator.state()).toEqual(before);
+    expect(editor.selection.ids).toEqual([firstId]);
+  });
+
+  it("undoes and redoes Shift-click selection as individual actions", async () => {
+    await editor.clickGlyphLocal(100, 100);
+    await editor.clickGlyphLocal(200, 200, { shiftKey: true });
+    expect(editor.selection.ids).toEqual([firstId, secondId]);
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([firstId]);
+
+    await editor.redo();
+    expect(editor.selection.ids).toEqual([firstId, secondId]);
+  });
+
+  it("coalesces a marquee gesture into one selection action", async () => {
+    await editor.dragScene({
+      down: { x: 80, y: 80 },
+      start: { x: 84, y: 80 },
+      end: { x: 130, y: 130 },
+    });
+    expect(editor.selection.ids).toEqual([firstId]);
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([]);
+
+    await editor.redo();
+    expect(editor.selection.ids).toEqual([firstId]);
+  });
+
+  it("compounds selecting and moving an unselected point", async () => {
+    const before = editor.pointPosition(firstId);
+    await editor.dragScene({
+      down: before,
+      start: { x: before.x + 4, y: before.y },
+      end: { x: before.x + 40, y: before.y + 30 },
+    });
+    expect(editor.selection.ids).toEqual([firstId]);
+    expect(editor.pointPosition(firstId)).toEqual({ x: before.x + 40, y: before.y + 30 });
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([]);
+    expect(editor.pointPosition(firstId)).toEqual(before);
+
+    await editor.redo();
+    expect(editor.selection.ids).toEqual([firstId]);
+    expect(editor.pointPosition(firstId)).toEqual({ x: before.x + 40, y: before.y + 30 });
+  });
+
+  it("compounds Delete with clearing and restoring its selection", async () => {
+    editor.selection.select([secondId]);
+
+    await editor.deleteSelection();
+    expect(editor.requireGlyphLayer().point(secondId)).toBeNull();
+    expect(editor.selection.ids).toEqual([]);
+
+    await editor.undo();
+    expect(editor.requireGlyphLayer().point(secondId)).not.toBeNull();
+    expect(editor.selection.ids).toEqual([secondId]);
+
+    await editor.redo();
+    expect(editor.requireGlyphLayer().point(secondId)).toBeNull();
+    expect(editor.selection.ids).toEqual([]);
+  });
+
+  it("discards selection changes from a canceled marquee", async () => {
+    editor.selection.select([secondId]);
+    const down = editor.projectSceneToScreen({ x: 80, y: 80 });
+    const end = editor.projectSceneToScreen({ x: 130, y: 130 });
+
+    editor.pointerDown(down.x, down.y);
+    editor.pointerMove(end.x, end.y);
+    editor.toolManager.cancelPointerGesture();
+    expect(editor.selection.ids).toEqual([secondId]);
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([]);
+  });
+
+  it("discards the renderer redo branch after a new selection action", async () => {
+    await editor.clickGlyphLocal(100, 100);
+    await editor.clickGlyphLocal(200, 200, { shiftKey: true });
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([firstId]);
+
+    await editor.click(9999, 9999);
+    expect(editor.selection.ids).toEqual([]);
+
+    await editor.redo();
+    expect(editor.selection.ids).toEqual([]);
+  });
+
+  it("discards the document redo branch after a new selection-only action", async () => {
+    editor.selectTool("pen");
+    await editor.clickGlyphLocal(300, 300);
+    expect(editor.pointCount).toBe(3);
+
+    await editor.undo();
+    expect(editor.pointCount).toBe(2);
+    expect(editor.selection.ids).toEqual([]);
+
+    const node = editor.glyphNode;
+    if (!node) throw new Error("Expected glyph node");
+    editor.selection.select([node.id]);
+    await editor.redo();
+
+    expect(editor.pointCount).toBe(2);
+    expect(editor.selection.ids).toEqual([node.id]);
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/editor/EditorHistory.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/EditorHistory.test.ts
@@ -58,6 +58,38 @@ describe("editor history", () => {
     expect(editor.selection.ids).toEqual([firstId]);
   });
 
+  it("undoes and redoes a Shift-marquee as one additive selection action", async () => {
+    editor.selection.select([secondId]);
+    await editor.dragScene({
+      down: { x: 60, y: 60 },
+      start: { x: 70, y: 60 },
+      end: { x: 130, y: 130 },
+      options: { shiftKey: true },
+    });
+    expect(editor.selection.ids).toEqual([secondId, firstId]);
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([secondId]);
+
+    await editor.redo();
+    expect(editor.selection.ids).toEqual([secondId, firstId]);
+  });
+
+  it("restores the original selection when Escape cancels a Shift-marquee", async () => {
+    editor.selection.select([secondId]);
+    const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+    const end = editor.projectSceneToScreen({ x: 130, y: 130 });
+
+    editor.pointerDown(down.x, down.y, { shiftKey: true });
+    editor.pointerMove(end.x, end.y, { shiftKey: true });
+    expect(editor.selection.ids).toEqual([secondId, firstId]);
+    editor.escape();
+    expect(editor.selection.ids).toEqual([secondId]);
+
+    await editor.undo();
+    expect(editor.selection.ids).toEqual([]);
+  });
+
   it("compounds selecting and moving an unselected point", async () => {
     const before = editor.pointPosition(firstId);
     await editor.dragScene({

--- a/apps/desktop/src/renderer/src/lib/editor/EditorHistory.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/EditorHistory.ts
@@ -1,0 +1,290 @@
+import type { LedgerEntryId } from "@shift/types";
+import type { EditorDiff, HistoryItem, PendingEditId, SelectableId } from "@/types";
+import type { WorkspaceEditCoordinator } from "@/lib/workspace/WorkspaceEditCoordinator";
+import { HistoryCapture } from "./HistoryCapture";
+import type { Selection } from "./Selection";
+import { sequenceDiff } from "./history/sequenceDiff";
+
+const MAX_HISTORY_ITEMS = 100;
+
+/**
+ * Orders renderer-owned editor diffs with references to Rust document entries.
+ *
+ * @remarks
+ * Document state pairs remain exclusively in the workspace ledger. This
+ * session-local history stores only pending/stable ledger identities and
+ * reversible editor diffs. Resetting an editor context drops this timeline and
+ * clears selection without changing document history.
+ */
+export class EditorHistory {
+  readonly #selection: Selection;
+  readonly #edits: WorkspaceEditCoordinator | null;
+  readonly #unsubscribeSelection: () => void;
+  readonly #unsubscribeEdits: (() => void) | null;
+  readonly #undoItems: HistoryItem[] = [];
+  readonly #redoItems: HistoryItem[] = [];
+
+  #capture: HistoryCapture | null = null;
+  #captureSelection: readonly SelectableId[] = [];
+  #captureDocument: PendingEditId | null = null;
+  #applying = false;
+
+  /**
+   * @param selection - Renderer-owned ordered selection to diff and restore.
+   * @param edits - Document replay authority, or null for a preview-only editor.
+   */
+  constructor(selection: Selection, edits: WorkspaceEditCoordinator | null) {
+    this.#selection = selection;
+    this.#edits = edits;
+    this.#unsubscribeSelection = selection.subscribe((before, after) =>
+      this.#selectionChanged(before, after),
+    );
+    this.#unsubscribeEdits =
+      edits?.subscribeEdits((editId) => this.#documentAccepted(editId)) ?? null;
+  }
+
+  get capturing(): boolean {
+    return this.#capture !== null;
+  }
+
+  /** Begins one action that may change editor values and at most one document entry. */
+  beginCapture(): HistoryCapture {
+    if (this.#capture) throw new Error("editor history already has an open capture");
+
+    this.#captureSelection = this.#selection.ids;
+    this.#captureDocument = null;
+
+    const capture = new HistoryCapture(
+      () => this.#finishCapture(capture),
+      () => this.#discardCapture(capture),
+    );
+    this.#capture = capture;
+    return capture;
+  }
+
+  /** Reverses the latest current-context action, falling back to document history. */
+  async undo(): Promise<boolean> {
+    if (this.#capture) throw new Error("cannot undo while an editor history capture is open");
+
+    const item = this.#undoItems.pop();
+    if (!item) return this.#undoDocument();
+
+    let documentReplayed = false;
+    try {
+      if (item.document !== null) {
+        const entryId = await this.#resolveEntryId(item.document);
+        if (!entryId || !(await this.#edits?.undo(entryId))) {
+          this.reset();
+          return false;
+        }
+        documentReplayed = true;
+      }
+
+      this.#applyEditorDiff(item.editor, true);
+      pushBounded(this.#redoItems, item);
+      return true;
+    } catch (error) {
+      if (documentReplayed) {
+        this.reset();
+      } else {
+        this.#undoItems.push(item);
+      }
+      throw error;
+    }
+  }
+
+  /** Reapplies the latest current-context action, falling back to document history. */
+  async redo(): Promise<boolean> {
+    if (this.#capture) throw new Error("cannot redo while an editor history capture is open");
+
+    const item = this.#redoItems.pop();
+    if (!item) return this.#redoDocument();
+
+    let documentReplayed = false;
+    try {
+      if (item.document !== null) {
+        const entryId = await this.#resolveEntryId(item.document);
+        if (!entryId || !(await this.#edits?.redo(entryId))) {
+          this.reset();
+          return false;
+        }
+        documentReplayed = true;
+      }
+
+      this.#applyEditorDiff(item.editor, false);
+      pushBounded(this.#undoItems, item);
+      return true;
+    } catch (error) {
+      if (documentReplayed) {
+        this.reset();
+      } else {
+        this.#redoItems.push(item);
+      }
+      throw error;
+    }
+  }
+
+  /** Drops session history and clears selection at an editor-context boundary. */
+  reset(): void {
+    if (this.#capture) this.#capture.discard();
+
+    this.#undoItems.length = 0;
+    this.#redoItems.length = 0;
+    this.#captureSelection = [];
+    this.#captureDocument = null;
+    this.#replaceSelection([]);
+  }
+
+  /** Permanently removes subscriptions without changing selection or document state. */
+  dispose(): void {
+    this.#unsubscribeSelection();
+    if (this.#unsubscribeEdits) this.#unsubscribeEdits();
+    this.#capture = null;
+    this.#undoItems.length = 0;
+    this.#redoItems.length = 0;
+  }
+
+  #finishCapture(capture: HistoryCapture): void {
+    if (this.#capture !== capture) return;
+
+    const editor = editorDiff(this.#captureSelection, this.#selection.ids);
+    const document = this.#captureDocument;
+    this.#capture = null;
+    this.#captureSelection = [];
+    this.#captureDocument = null;
+    if (!editor && document === null) return;
+
+    this.#push({ document, editor });
+  }
+
+  #discardCapture(capture: HistoryCapture): void {
+    if (this.#capture !== capture) return;
+
+    const selection = this.#captureSelection;
+    const document = this.#captureDocument;
+    this.#capture = null;
+    this.#captureSelection = [];
+    this.#captureDocument = null;
+
+    if (document !== null) {
+      this.#push({ document, editor: editorDiff(selection, this.#selection.ids) });
+      return;
+    }
+
+    this.#replaceSelection(selection);
+  }
+
+  #selectionChanged(before: readonly SelectableId[], after: readonly SelectableId[]): void {
+    if (this.#applying || this.#capture) return;
+
+    const editor = editorDiff(before, after);
+    if (editor) this.#push({ document: null, editor });
+  }
+
+  #documentAccepted(editId: PendingEditId): void {
+    if (this.#capture) {
+      if (this.#captureDocument !== null && this.#captureDocument !== editId) {
+        throw new Error("one editor history capture cannot contain multiple document entries");
+      }
+
+      this.#captureDocument = editId;
+      return;
+    }
+
+    this.#push({ document: editId, editor: null });
+  }
+
+  #push(item: HistoryItem): void {
+    this.#redoItems.length = 0;
+    pushBounded(this.#undoItems, item);
+
+    if (item.document !== null || !this.#edits?.hasRedo) return;
+
+    void this.#discardDocumentRedo();
+  }
+
+  async #discardDocumentRedo(): Promise<void> {
+    if (!this.#edits) return;
+
+    try {
+      await this.#edits.discardRedo();
+    } catch (error) {
+      console.error("failed to discard the document redo branch", error);
+      this.reset();
+    }
+  }
+
+  async #resolveEntryId(reference: PendingEditId | LedgerEntryId): Promise<LedgerEntryId | null> {
+    if (typeof reference === "string") return reference;
+    if (!this.#edits) return null;
+
+    await this.#edits.settled();
+    return this.#edits.ledgerEntryId(reference);
+  }
+
+  async #undoDocument(): Promise<boolean> {
+    if (!this.#edits) return false;
+
+    const applied = await this.#edits.undo();
+    const entryId = applied?.ledgerEntryId;
+    if (!entryId) return false;
+
+    pushBounded(this.#redoItems, { document: entryId, editor: null });
+    return true;
+  }
+
+  async #redoDocument(): Promise<boolean> {
+    if (!this.#edits) return false;
+
+    const applied = await this.#edits.redo();
+    const entryId = applied?.ledgerEntryId;
+    if (!entryId) return false;
+
+    pushBounded(this.#undoItems, { document: entryId, editor: null });
+    return true;
+  }
+
+  #applyEditorDiff(editor: EditorDiff | null, reverse: boolean): void {
+    const diff = editor?.selection;
+    if (!diff) return;
+
+    const removed = reverse ? diff.inserted : diff.removed;
+    const inserted = reverse ? diff.removed : diff.inserted;
+    const current = this.#selection.ids;
+    assertSequence(current, diff.start, removed);
+
+    const next = [...current];
+    next.splice(diff.start, removed.length, ...inserted);
+    this.#replaceSelection(next);
+  }
+
+  #replaceSelection(ids: readonly SelectableId[]): void {
+    this.#applying = true;
+    try {
+      this.#selection.select(ids);
+    } finally {
+      this.#applying = false;
+    }
+  }
+}
+
+function editorDiff(
+  before: readonly SelectableId[],
+  after: readonly SelectableId[],
+): EditorDiff | null {
+  const selection = sequenceDiff(before, after);
+  return selection ? { selection } : null;
+}
+
+function assertSequence<T>(items: readonly T[], start: number, expected: readonly T[]): void {
+  for (let index = 0; index < expected.length; index++) {
+    if (items[start + index] !== expected[index]) {
+      throw new Error("editor history selection no longer matches its recorded diff");
+    }
+  }
+}
+
+function pushBounded<T>(items: T[], item: T): void {
+  items.push(item);
+  if (items.length > MAX_HISTORY_ITEMS) items.shift();
+}

--- a/apps/desktop/src/renderer/src/lib/editor/HistoryCapture.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/HistoryCapture.ts
@@ -1,0 +1,36 @@
+/**
+ * Owns one open user-action capture spanning renderer and document changes.
+ *
+ * @remarks
+ * `finish()` records the net editor diff and attached document operation.
+ * `discard()` restores the starting editor values and records nothing. Both
+ * terminal calls are idempotent; a finished or discarded capture cannot reopen.
+ */
+export class HistoryCapture {
+  readonly #finishCapture: () => void;
+  readonly #discardCapture: () => void;
+  #status: "open" | "finished" | "discarded" = "open";
+
+  /**
+   * @param finishCapture - Publishes the completed action once.
+   * @param discardCapture - Restores the action's starting editor values once.
+   */
+  constructor(finishCapture: () => void, discardCapture: () => void) {
+    this.#finishCapture = finishCapture;
+    this.#discardCapture = discardCapture;
+  }
+
+  finish(): void {
+    if (this.#status !== "open") return;
+
+    this.#status = "finished";
+    this.#finishCapture();
+  }
+
+  discard(): void {
+    if (this.#status !== "open") return;
+
+    this.#status = "discarded";
+    this.#discardCapture();
+  }
+}

--- a/apps/desktop/src/renderer/src/lib/editor/Selection.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/Selection.ts
@@ -1,7 +1,12 @@
 import { computed, type Signal } from "@/lib/signals/signal";
 import type { ShiftStore } from "@/lib/store/ShiftStore";
 import { uniqueInOrder } from "@/lib/utils/utils";
-import { currentSelectionId, type SelectableId, type ShiftEditorRecord } from "@/types";
+import {
+  currentSelectionId,
+  type SelectableId,
+  type SelectionListener,
+  type ShiftEditorRecord,
+} from "@/types";
 
 export interface SelectionState {
   readonly ids: readonly SelectableId[];
@@ -22,6 +27,7 @@ function emptySelectionState(): SelectionState {
 export class Selection {
   readonly #store: ShiftStore<ShiftEditorRecord>;
   readonly #ids: Signal<ReadonlySet<SelectableId>>;
+  readonly #listeners = new Set<SelectionListener>();
   readonly stateCell: Signal<SelectionState>;
 
   constructor(store: ShiftStore<ShiftEditorRecord>) {
@@ -51,6 +57,17 @@ export class Selection {
    */
   get ids(): readonly SelectableId[] {
     return [...this.stateCell.peek().ids];
+  }
+
+  /**
+   * Observes complete ordered replacements after they are published.
+   *
+   * @param listener - Receives immutable before/after selection values.
+   * @returns A function that permanently removes this listener.
+   */
+  subscribe(listener: SelectionListener): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
   }
 
   has(id: SelectableId): boolean {
@@ -97,9 +114,11 @@ export class Selection {
   }
 
   clear(): void {
-    if (!this.hasSelection()) return;
+    const before = this.stateCell.peek().ids;
+    if (before.length === 0) return;
 
     this.#store.delete(currentSelectionId);
+    this.#publish(before, []);
   }
 
   #write(ids: readonly SelectableId[]): void {
@@ -108,11 +127,17 @@ export class Selection {
       return;
     }
 
+    const before = this.stateCell.peek().ids;
     this.#store.put({
       id: currentSelectionId,
       type: "selection",
       scope: "session",
       ids,
     });
+    this.#publish(before, ids);
+  }
+
+  #publish(before: readonly SelectableId[], after: readonly SelectableId[]): void {
+    for (const listener of this.#listeners) listener(before, after);
   }
 }

--- a/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/editor/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Editor
 
-<!-- reviewed: 2026-09-04 -->
+<!-- reviewed: 2026-09-06 -->
 
 Central orchestrator for the canvas-based glyph editing surface, wiring viewport transforms, selection, rendering, hit testing, and tool management into a single facade.
 
@@ -38,6 +38,10 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 
 **Architecture Invariant:** `Selection` is a dumb ordered set of branded object IDs. Mutations go through `select()`, `add()`, `remove()`, and `toggle()`; behavior and live bounds come from resolving those IDs through `Editor.object()`.
 
+**Architecture Invariant:** `EditorHistory` is the renderer-owned undo timeline. A `HistoryItem` holds an optional `EditorDiff` and only a reference to an optional Rust ledger entry; document state pairs never move into the renderer. Selection uses a single-splice `SequenceDiff`, so Select All records only the changed range. Tool gestures, Delete, Cut, Paste, Duplicate, Pen, Shape, and boolean operations finish one `HistoryCapture` after both editor and document changes. Discarded gestures restore their starting selection and record nothing. Hover, camera, tool choice, and transient drag state are not undoable editor properties.
+
+**Architecture Invariant:** Pure editor actions do not create Rust ledger entries or dirty the document. Branching after undo calls the workspace's explicit redo discard only when needed. Entering or leaving an editor route resets renderer history and selection without changing document history.
+
 **Architecture Invariant:** Glyph-domain hit testing belongs to glyph geometry and editor glyph lookup helpers. Tool-specific controls, such as select bounding-box handles, are owned and hit-tested by the tool that renders them.
 
 **Architecture Invariant:** `Handles` tries the accelerated marker layer first and falls back to CPU canvas drawing if WebGL is unavailable. The marker-layer path packs all handle instances into a `Float32Array` for a single draw call. Handle styling describes location, not session capability: exact sources retain ordinary styles in authored and preview sessions; locations between sources use the `interpolated` theme state, including named instances unless they coincide with a source. This state overrides hover and selection styling without hiding handles during scrubbing.
@@ -47,6 +51,11 @@ Central orchestrator for the canvas-based glyph editing surface, wiring viewport
 ```
 editor/
   Editor.ts              -- Facade (~1373 lines), wires all subsystems
+  EditorHistory.ts       -- Renderer diffs ordered with Rust ledger identities
+  HistoryCapture.ts      -- One finishable/discardable user action
+  Selection.ts           -- Ordered renderer-owned selected object identities
+  history/
+    sequenceDiff.ts      -- Minimal single-splice sequence difference
   lifecycle.ts           -- EventEmitter for destruction and preview mutation notices
   managers/
     Camera.ts             -- UPM<->screen affine matrices, zoom, pan
@@ -65,7 +74,7 @@ editor/
 
 ## Key Types
 
-- **`Editor`** -- Facade class. Owns `Selection`, `Hover`, `Camera`, `Renderer`, `ToolManager`, `Clipboard`, `EventEmitter`, and the workspace transaction facade. Its immutable `sessionMode` lets Select suppress geometry interaction; geometry clicks publish `previewMutationAttempted` for presentation code. The canvas lock is display-only. Passed directly to tools and NodeDefinitions; `glyphForId()` exposes already-acquired canonical Glyphs without exposing FontStore.
+- **`Editor`** -- Facade class. Owns `Selection`, `EditorHistory`, `Hover`, `Camera`, `Renderer`, `ToolManager`, `Clipboard`, `EventEmitter`, and the workspace transaction facade. Its immutable `sessionMode` lets Select suppress geometry interaction; geometry clicks publish `previewMutationAttempted` for presentation code. The canvas lock is display-only. Passed directly to tools and NodeDefinitions; `glyphForId()` exposes already-acquired canonical Glyphs without exposing FontStore.
 - **`Scene`** -- Owns generic, serializable placed-node records and node-level queries. Glyph acquisition and retained object ownership remain outside Scene.
 - **`ShiftStore<ShiftEditorRecord>`** -- Editor-owned generic record store for scene nodes, selection, editing, and text runs.
 - **`FontStore`** -- Workspace-owned renderer mirror injected privately into Editor for synchronous lookup of already-loaded Glyph objects.
@@ -73,7 +82,9 @@ editor/
 - **`Renderer`** -- Manages four stacked canvas layers (background, scene, markers/WebGL, overlay), their `FrameHandler` instances, and the canvas item layers that draw each pass.
 - **`Canvas`** -- Thin wrapper around `CanvasRenderingContext2D` with `pxToUpm()` conversion and themed drawing primitives. Carries `CameraTransform` and `Theme`.
 - **`CameraTransform`** -- Value object: `{ zoom, panX, panY, centre, upmScale, logicalHeight, layoutHeight, padding, descender }`. Snapshot of viewport state passed to rendering code.
-- **`Selection`** -- Ordered branded-ID selection state. It exposes `stateCell` and unwrapped ID getters; `Editor.selectionBoundsCell` resolves current live objects and their bounds.
+- **`Selection`** -- Ordered branded-ID selection state. It exposes `stateCell`, unwrapped ID getters, and replacement notifications; `Editor.selectionBoundsCell` resolves current live objects and their bounds.
+- **`EditorHistory`** -- Session-local ordering of selection diffs and stable document-ledger references. It owns undo/redo branching and falls back to ordinary Rust document replay when no renderer item is available.
+- **`HistoryCapture`** -- One open user action. `finish()` stores its net editor diff plus document reference; `discard()` restores its starting selection when no document entry was accepted.
 - **`SelectableId`** -- Branded identity accepted by selection regardless of the object's concrete kind.
 - **`Coordinates`** -- Pair of `{ screen, scene }` for a single pointer position. Node-local coordinates are derived after hit testing identifies the node being acted on.
 - **`PositionSelection`** -- One active authored `GlyphLayer` paired with normalized point/anchor targets. It contains edit ownership only, not scene placement or pointer coordinates.
@@ -88,6 +99,10 @@ editor/
 ### Construction and wiring
 
 Workspace constructs `Editor` with the public `Font` model and its matching private `FontStore`. Editor creates its own `ShiftStore<ShiftEditorRecord>`, then wires managers and reactive effects. The rendering effects each read a specific set of signals and schedule the matching canvas layer for redraw. A cursor effect reads tool/hover state and updates the CSS cursor.
+
+### Editor and document history
+
+`Selection` publishes complete ordered before/after values to `EditorHistory`, which stores only the minimal changed range. `WorkspaceEditCoordinator` synchronously publishes each accepted pending edit ID and resolves it to a stable Rust ledger ID after its serialized apply settles. A finished capture joins those two references into one `HistoryItem`; undo/redo asks Rust to replay exactly that document entry before applying the renderer diff in reverse/forward order. A selection-only branch clears Rust redo explicitly but neither applies an intent nor changes dirty state.
 
 ### Coordinate pipeline
 
@@ -172,7 +187,7 @@ Glyph geometry exposes domain hit queries for points, anchors, and segments. Too
 - Outcome tests treat editor actions as asynchronous: metric setters need `await editor.settle()` before asserting, clipboard and history actions (`copy`, `paste`, `undo`, `redo`) return promises that must be awaited, and drag helpers give every drag sample its cumulative delta from the pointer-down origin.
 - `pnpm test:desktop src/renderer/src/lib/model/positions/PositionEdits.test.ts` -- position-edit (move/rotate/scale) tests.
 - `pnpm test:desktop src/renderer/src/lib/editor/managers/Camera.test.ts` -- camera manager tests.
-- `pnpm test:e2e:visual e2e/glyph-navigation.spec.ts e2e/glyph-view.spec.ts e2e/tools.spec.ts` -- stale/transient navigation, stable UPM framing, and DOM cancellation evidence.
+- `pnpm test:e2e:visual e2e/glyph-navigation.spec.ts e2e/glyph-view.spec.ts e2e/tools.spec.ts e2e/selection-history.spec.ts` -- stale/transient navigation, stable UPM framing, DOM cancellation, and compound renderer/document history evidence.
 - Manual: open a preview font, verify Pen and Shape are disabled, drag a selection marquee without selecting points, click geometry or the sidebar lock, and verify the notice offers conversion only for convertible sources. The canvas lock must not open a notice.
 
 ## Related

--- a/apps/desktop/src/renderer/src/lib/editor/history/sequenceDiff.test.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/history/sequenceDiff.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { sequenceDiff } from "./sequenceDiff";
+
+describe("ordered sequence differences", () => {
+  it("returns null for equal sequences", () => {
+    expect(sequenceDiff(["a", "b"], ["a", "b"])).toBeNull();
+  });
+
+  it("retains only an appended item", () => {
+    expect(sequenceDiff(["a"], ["a", "b"])).toEqual({
+      start: 1,
+      removed: [],
+      inserted: ["b"],
+    });
+  });
+
+  it("retains only a removed middle item", () => {
+    expect(sequenceDiff(["a", "b", "c"], ["a", "c"])).toEqual({
+      start: 1,
+      removed: ["b"],
+      inserted: [],
+    });
+  });
+
+  it("preserves reordered contents as one reversible range", () => {
+    expect(sequenceDiff(["a", "b", "c", "d"], ["a", "c", "b", "d"])).toEqual({
+      start: 1,
+      removed: ["b", "c"],
+      inserted: ["c", "b"],
+    });
+  });
+});

--- a/apps/desktop/src/renderer/src/lib/editor/history/sequenceDiff.ts
+++ b/apps/desktop/src/renderer/src/lib/editor/history/sequenceDiff.ts
@@ -1,0 +1,32 @@
+import type { SequenceDiff } from "@/types";
+
+/**
+ * Returns the smallest single-splice difference between two ordered sequences.
+ *
+ * @param before - Sequence before the change.
+ * @param after - Sequence after the change.
+ * @returns A reversible changed range, or null when both sequences are equal.
+ */
+export function sequenceDiff<T>(before: readonly T[], after: readonly T[]): SequenceDiff<T> | null {
+  const sharedLength = Math.min(before.length, after.length);
+  let start = 0;
+
+  while (start < sharedLength && before[start] === after[start]) {
+    start += 1;
+  }
+
+  if (start === before.length && start === after.length) return null;
+
+  let beforeEnd = before.length;
+  let afterEnd = after.length;
+  while (beforeEnd > start && afterEnd > start && before[beforeEnd - 1] === after[afterEnd - 1]) {
+    beforeEnd -= 1;
+    afterEnd -= 1;
+  }
+
+  return {
+    start,
+    removed: before.slice(start, beforeEnd),
+    inserted: after.slice(start, afterEnd),
+  };
+}

--- a/apps/desktop/src/renderer/src/lib/nodes/GlyphNodeDefinition.ts
+++ b/apps/desktop/src/renderer/src/lib/nodes/GlyphNodeDefinition.ts
@@ -279,14 +279,24 @@ export class GlyphNodeDefinition extends NodeDefinition<GlyphNode> {
     const tool = this.editor.toolCell.peek();
     if (tool?.id === "select" && tool.state.type === "translating") return [];
 
+    const view = this.#view(node);
+    if (!view) return [];
+
     const segmentIds: SegmentId[] = [];
+    const selection = this.editor.selection;
 
-    for (const object of this.editor.objects(this.editor.selection.ids)) {
-      if (object.kind !== "segment") continue;
-      if (object.node.id !== node.id) continue;
-      if (!this.editor.handlesVisible(object.contourId)) continue;
+    for (const { contour, component } of view.contours) {
+      if (component !== null || !this.editor.handlesVisible(contour.id)) continue;
 
-      segmentIds.push(object.segmentId);
+      for (const segment of contour.segments()) {
+        if (
+          selection.has(contour.id) ||
+          selection.has(segment.id) ||
+          segment.pointIds.every((pointId) => selection.has(pointId))
+        ) {
+          segmentIds.push(segment.id);
+        }
+      }
     }
 
     return segmentIds;

--- a/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/core/ToolManager.ts
@@ -1,5 +1,6 @@
 import type { Point2D } from "@shift/geo";
 import type { Editor } from "@/lib/editor/Editor";
+import type { HistoryCapture } from "@/lib/editor/HistoryCapture";
 import type { ToolSwitchHandler, TemporaryToolOptions } from "@/types/editor";
 import type { ToolName } from "./createContext";
 import {
@@ -36,6 +37,7 @@ export class ToolManager implements ToolSwitchHandler {
   private gesture = new GestureDetector();
   private editor: Editor;
   private pendingReplacements = new Set<ToolName>();
+  #historyCapture: HistoryCapture | null = null;
 
   private temporaryOptions: TemporaryToolOptions | null = null;
 
@@ -230,7 +232,7 @@ export class ToolManager implements ToolSwitchHandler {
     this.gesture.reset();
     this.editor.gesture.reset();
     if (wasDragging) {
-      this.activeTool?.handleEvent({ type: "dragCancel" });
+      this.#dispatchEvent({ type: "dragCancel" });
     }
     this.#flushPendingReplacements();
   }
@@ -249,13 +251,11 @@ export class ToolManager implements ToolSwitchHandler {
       return true;
     }
 
-    return (
-      this.activeTool?.handleEvent({
-        type: "keyDown",
-        key: e.key,
-        ...modifiers,
-      }) ?? false
-    );
+    return this.#dispatchEvent({
+      type: "keyDown",
+      key: e.key,
+      ...modifiers,
+    });
   }
 
   handleKeyUp(e: KeyboardEvent): boolean {
@@ -267,13 +267,11 @@ export class ToolManager implements ToolSwitchHandler {
     });
     this.editor.input.setModifiers(modifiers);
 
-    return (
-      this.activeTool?.handleEvent({
-        type: "keyUp",
-        key: e.key,
-        ...modifiers,
-      }) ?? false
-    );
+    return this.#dispatchEvent({
+      type: "keyUp",
+      key: e.key,
+      ...modifiers,
+    });
   }
 
   drawBackground(canvas: Canvas): void {
@@ -317,12 +315,79 @@ export class ToolManager implements ToolSwitchHandler {
   }
 
   notifySelectionChanged(): void {
-    this.activeTool?.handleEvent({ type: "selectionChanged" });
+    this.#dispatchEvent({ type: "selectionChanged" });
   }
 
   private dispatchEvents(events: GestureEvent[]): void {
     for (const event of events) {
-      this.activeTool?.handleEvent(this.withPointerTarget(event));
+      this.#dispatchEvent(this.withPointerTarget(event));
+    }
+  }
+
+  #dispatchEvent(event: ToolEvent): boolean {
+    switch (event.type) {
+      case "dragStart": {
+        this.#historyCapture?.discard();
+        const capture = this.editor.history.beginCapture();
+        this.#historyCapture = capture;
+
+        try {
+          return this.activeTool?.handleEvent(event) ?? false;
+        } catch (error) {
+          capture.discard();
+          this.#historyCapture = null;
+          throw error;
+        }
+      }
+
+      case "dragEnd": {
+        const capture = this.#historyCapture;
+        this.#historyCapture = null;
+
+        try {
+          const handled = this.activeTool?.handleEvent(event) ?? false;
+          capture?.finish();
+          return handled;
+        } catch (error) {
+          capture?.discard();
+          throw error;
+        }
+      }
+
+      case "dragCancel": {
+        const capture = this.#historyCapture;
+        this.#historyCapture = null;
+
+        try {
+          return this.activeTool?.handleEvent(event) ?? false;
+        } finally {
+          capture?.discard();
+        }
+      }
+
+      case "drag":
+      case "pointerMove":
+        return this.activeTool?.handleEvent(event) ?? false;
+
+      case "click":
+      case "doubleClick":
+      case "keyDown":
+      case "keyUp":
+      case "selectionChanged": {
+        if (this.editor.history.capturing) {
+          return this.activeTool?.handleEvent(event) ?? false;
+        }
+
+        const capture = this.editor.history.beginCapture();
+        try {
+          const handled = this.activeTool?.handleEvent(event) ?? false;
+          capture.finish();
+          return handled;
+        } catch (error) {
+          capture.discard();
+          throw error;
+        }
+      }
     }
   }
 

--- a/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
+++ b/apps/desktop/src/renderer/src/lib/tools/docs/DOCS.md
@@ -1,6 +1,6 @@
 # Tools
 
-<!-- reviewed: 2026-09-02 -->
+<!-- reviewed: 2026-09-06 -->
 
 State machine-based tool system for the Shift font editor: translates pointer/keyboard input into tool-specific state transitions and rendering.
 
@@ -21,6 +21,8 @@ State machine-based tool system for the Shift font editor: translates pointer/ke
 - **Architecture Invariant:** Behaviors do NOT render. All rendering belongs in the tool's `drawOverlay` / `drawScene` / `drawBackground` methods.
 
 - **Architecture Invariant:** `ToolManager` coalesces pointer-move events via `requestAnimationFrame`. The synchronous pointer handler only stores input; projection, hit-test, and tool dispatch run in the rAF callback. **CRITICAL**: reading layout-dependent state synchronously in the pointer handler will see stale data.
+
+- **Architecture Invariant:** `ToolManager` brackets each click/key event and complete drag lifecycle in one `HistoryCapture`. `dragEnd` finishes it after tool commit; `dragCancel` or a thrown handler discards it after tool rollback. Behaviors mutate selection and document state normally and must not open nested history captures.
 
 - **Architecture Invariant:** `ToolContext.setState` inside a behavior's event handler updates a local `nextState` variable, not `this.state` on the tool. `BaseTool` commits the new state and fires lifecycle hooks (`onStateExit`, `onStateEnter`, `onStateChange`) only after the behavior loop returns. Calling `setState` multiple times within one handler is legal; only the final value is committed.
 
@@ -91,6 +93,7 @@ User pointer/key
 - Pointer-up drains queued movement and emits the final `drag` sample before `dragEnd`. Both release events use the final pointer position with the latest drag sample's modifiers, so releasing Shift just before mouseup does not change the preview's constraints. Modifier changes take effect on the next processed drag movement; clicks and double-clicks still use release-time modifiers. `GestureDetector.lastDragModifiers` is empty before dragging, follows each emitted drag movement, and clears on completion, cancellation, or a new pointer-down.
 - Behaviors initialize on `dragStart`, register rollback with `ctx.onCancel()`, preview from `drag`, and commit on `dragEnd` before dismissing rollback.
 - `BaseTool` runs any rollback left active at `dragEnd`, `dragCancel`, tool disposal, or after a handler throws.
+- `ToolManager` keeps the matching `HistoryCapture` open from `dragStart` through terminal dispatch, so initial selection, final document commit, and net selection are one undo step; cancellation restores the pre-drag selection and records nothing.
 
 ### Shape authoring
 

--- a/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/pen/Pen.test.ts
@@ -276,12 +276,15 @@ describe("Pen tool", () => {
     it("a click-placed point survives as one undoable ledger entry", async () => {
       await editor.click(100, 200);
       expect(editor.pointCount).toBe(1);
+      const selection = editor.selection.ids;
 
       await editor.undo();
       expect(editor.pointCount).toBe(0);
+      expect(editor.selection.ids).toEqual([]);
 
       await editor.redo();
       expect(editor.pointCount).toBe(1);
+      expect(editor.selection.ids).toEqual(selection);
     });
 
     it("a curve drag appends complete topology in one undo step", async () => {

--- a/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/BoundingBox.ts
@@ -101,15 +101,20 @@ export class SelectBoundingBox extends CanvasItem<SelectBoundingBoxProps> {
 
   protected props(): SelectBoundingBoxProps | null {
     const state = this.#select.stateCell.value;
-    if (state.type === "brushing") return null;
+    if (state.type === "brushing" && !this.#editor.input.modifiersCell.value.shiftKey) return null;
 
     track(this.#editor.selection.stateCell);
-    const selection = this.#editor.positionSelection(this.#editor.selection.ids);
+    const ids =
+      state.type === "brushing" ? state.selection.initialSelection : this.#editor.selection.ids;
+    const selection = this.#editor.positionSelection(ids);
     const pointCount = selection?.targets.points?.length ?? 0;
     const anchorCount = selection?.targets.anchors?.length ?? 0;
     if (!selection || pointCount + anchorCount <= 1) return null;
 
-    const sceneRect = this.#editor.selectionBoundsCell.value;
+    const sceneRect =
+      state.type === "brushing"
+        ? this.#editor.selectionBounds(ids)
+        : this.#editor.selectionBoundsCell.value;
     if (!sceneRect) return null;
 
     this.#editor.camera.trackViewportTransform();
@@ -145,6 +150,8 @@ export class SelectBoundingBox extends CanvasItem<SelectBoundingBoxProps> {
   }
 
   hit(coords: Coordinates): BoundingBoxHitResult {
+    if (this.#select.stateCell.peek().type === "brushing") return null;
+
     const props = this.propsSnapshot();
     if (!props) return null;
 
@@ -193,6 +200,8 @@ export class SelectBoundingBox extends CanvasItem<SelectBoundingBoxProps> {
   }
 
   containsTranslationPoint(coords: Coordinates): boolean {
+    if (this.#select.stateCell.peek().type === "brushing") return false;
+
     const props = this.propsSnapshot();
     if (!props) return false;
 

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.test.ts
@@ -117,6 +117,147 @@ describe("Select tool", () => {
       });
     });
 
+    describe("marquee selection", () => {
+      let firstId: PointId;
+      let secondId: PointId;
+      let thirdId: PointId;
+
+      beforeEach(async () => {
+        const pointIds = await editor.drawOpenContour([
+          { x: 100, y: 100 },
+          { x: 200, y: 200 },
+          { x: 300, y: 300 },
+        ]);
+        if (!pointIds[0] || !pointIds[1] || !pointIds[2]) throw new Error("Expected three points");
+        [firstId, secondId, thirdId] = pointIds;
+        editor.selectTool("select");
+      });
+
+      it.each([false, true])(
+        "preserves the prior selection only with Shift: %s",
+        async (shiftKey) => {
+          editor.selection.select([secondId]);
+
+          await editor.dragScene({
+            down: { x: 60, y: 60 },
+            start: { x: 70, y: 60 },
+            end: { x: 130, y: 130 },
+            options: { shiftKey },
+          });
+
+          expect(editor.selection.ids).toEqual(shiftKey ? [secondId, firstId] : [firstId]);
+        },
+      );
+
+      it("preserves the selection when a Shift-marquee contains no points", async () => {
+        editor.selection.select([secondId]);
+
+        await editor.dragScene({
+          down: { x: 60, y: 60 },
+          start: { x: 70, y: 60 },
+          end: { x: 80, y: 80 },
+          options: { shiftKey: true },
+        });
+
+        expect(editor.selection.ids).toEqual([secondId]);
+      });
+
+      it("does not toggle off already-selected points inside a Shift-marquee", async () => {
+        editor.selection.select([firstId, secondId]);
+
+        await editor.dragScene({
+          down: { x: 60, y: 60 },
+          start: { x: 70, y: 60 },
+          end: { x: 130, y: 130 },
+          options: { shiftKey: true },
+        });
+
+        expect(editor.selection.ids).toEqual([firstId, secondId]);
+      });
+
+      it("drops only newly brushed points when a Shift-marquee shrinks", () => {
+        editor.selection.select([secondId]);
+        const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+        const end = editor.projectSceneToScreen({ x: 130, y: 130 });
+        const start = editor.projectSceneToScreen({ x: 80, y: 80 });
+
+        editor.pointerDown(down.x, down.y, { shiftKey: true });
+        editor.pointerMove(end.x, end.y, { shiftKey: true });
+        expect(editor.selection.ids).toEqual([secondId, firstId]);
+        editor.pointerMove(start.x, start.y, { shiftKey: true });
+        expect(editor.selection.ids).toEqual([secondId]);
+        editor.pointerUp(start.x, start.y, { shiftKey: true });
+
+        expect(editor.selection.ids).toEqual([secondId]);
+      });
+
+      it.each([false, true])(
+        "keeps the selection box visible during Shift-marquee only: %s",
+        (shiftKey) => {
+          editor.selection.select([firstId, secondId]);
+          const select = editor.toolManager.activeTool;
+          if (!(select instanceof Select)) throw new Error("Expected Select tool");
+          const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+          const end = editor.projectSceneToScreen({ x: 80, y: 80 });
+
+          expect(select.boundingBox.visible).toBe(true);
+          editor.pointerDown(down.x, down.y, { shiftKey });
+          expect(select.boundingBox.visible).toBe(true);
+          editor.pointerMove(end.x, end.y, { shiftKey });
+          expect(select.boundingBox.visible).toBe(shiftKey);
+          editor.pointerUp(end.x, end.y, { shiftKey });
+          expect(select.boundingBox.visible).toBe(shiftKey);
+        },
+      );
+
+      it("keeps the old box fixed until a Shift-marquee is released", () => {
+        editor.selection.select([secondId, thirdId]);
+        const select = editor.toolManager.activeTool;
+        if (!(select instanceof Select)) throw new Error("Expected Select tool");
+        const before = select.boundingBox.rect;
+        const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+        const end = editor.projectSceneToScreen({ x: 130, y: 130 });
+
+        editor.pointerDown(down.x, down.y, { shiftKey: true });
+        expect(select.boundingBox.rect).toEqual(before);
+        editor.pointerMove(end.x, end.y, { shiftKey: true });
+        expect(editor.selection.ids).toEqual([secondId, thirdId, firstId]);
+        expect(select.boundingBox.rect).toEqual(before);
+        editor.pointerUp(end.x, end.y, { shiftKey: true });
+        expect(select.boundingBox.rect).toEqual(editor.selectionBounds());
+        expect(select.boundingBox.rect).not.toEqual(before);
+      });
+
+      it("waits for release to show a new box when Shift-marquee starts without a selection", () => {
+        const select = editor.toolManager.activeTool;
+        if (!(select instanceof Select)) throw new Error("Expected Select tool");
+        const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+        const end = editor.projectSceneToScreen({ x: 230, y: 230 });
+
+        editor.pointerDown(down.x, down.y, { shiftKey: true });
+        editor.pointerMove(end.x, end.y, { shiftKey: true });
+        expect(editor.selection.ids).toEqual([firstId, secondId]);
+        expect(select.boundingBox.visible).toBe(false);
+        editor.pointerUp(end.x, end.y, { shiftKey: true });
+        expect(select.boundingBox.visible).toBe(true);
+      });
+
+      it("uses the pre-drag selection when Shift is pressed during a marquee", () => {
+        editor.selection.select([secondId]);
+        const down = editor.projectSceneToScreen({ x: 60, y: 60 });
+        const end = editor.projectSceneToScreen({ x: 130, y: 130 });
+
+        editor.pointerDown(down.x, down.y);
+        editor.pointerMove(end.x, end.y);
+        expect(editor.selection.ids).toEqual([firstId]);
+        editor.pointerMove(end.x, end.y, { shiftKey: true });
+        expect(editor.selection.ids).toEqual([secondId, firstId]);
+        editor.pointerUp(end.x, end.y, { shiftKey: true });
+
+        expect(editor.selection.ids).toEqual([secondId, firstId]);
+      });
+    });
+
     it("drags a selected point", async () => {
       editor.selectTool("pen");
       await editor.clickGlyphLocal(100, 200);

--- a/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/Select.ts
@@ -117,7 +117,11 @@ export class Select extends BaseTool<SelectState, Select> {
         return {
           state: {
             type: "brushing",
-            selection: { startPos: event.origin.scene, currentPos: event.coords.scene },
+            selection: {
+              startPos: event.origin.scene,
+              currentPos: event.coords.scene,
+              initialSelection: [],
+            },
           },
         };
 

--- a/apps/desktop/src/renderer/src/lib/tools/select/behaviors/Marquee.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/behaviors/Marquee.ts
@@ -1,5 +1,6 @@
 import { Rect, Vec2, type Rect2D } from "@shift/geo";
 import type { PointId } from "@shift/types";
+import type { SelectableId } from "@/types";
 import type { ToolContext } from "../../core/Behavior";
 import type { DragEndEvent, DragEvent, DragStartEvent } from "../../core/GestureDetector";
 import type { SelectBehavior, SelectState } from "../types";
@@ -8,7 +9,8 @@ export class Marquee implements SelectBehavior {
   onDragStart(state: SelectState, ctx: ToolContext<SelectState>, event: DragStartEvent): boolean {
     if (state.type !== "ready") return false;
 
-    if (ctx.editor.selection.hasSelection()) {
+    const initialSelection = ctx.editor.selection.ids;
+    if (!event.shiftKey && ctx.editor.selection.hasSelection()) {
       ctx.editor.selection.clear();
     }
 
@@ -17,6 +19,7 @@ export class Marquee implements SelectBehavior {
       selection: {
         startPos: event.origin.scene,
         currentPos: event.coords.scene,
+        initialSelection,
       },
     });
 
@@ -27,7 +30,7 @@ export class Marquee implements SelectBehavior {
     if (state.type !== "brushing") return false;
 
     const rect = Rect.fromPoints(state.selection.startPos, event.coords.scene);
-    this.selectPointsInRect(rect, ctx);
+    this.selectPointsInRect(rect, ctx, event.shiftKey ? state.selection.initialSelection : []);
 
     ctx.setState({
       type: "brushing",
@@ -40,7 +43,7 @@ export class Marquee implements SelectBehavior {
     if (state.type !== "brushing") return false;
 
     const rect = Rect.fromPoints(state.selection.startPos, event.coords.scene);
-    this.selectPointsInRect(rect, ctx);
+    this.selectPointsInRect(rect, ctx, event.shiftKey ? state.selection.initialSelection : []);
 
     ctx.setState({ type: "ready" });
     return true;
@@ -72,13 +75,17 @@ export class Marquee implements SelectBehavior {
     return pointIds;
   }
 
-  private selectPointsInRect(rect: Rect2D, ctx: ToolContext<SelectState>): void {
+  private selectPointsInRect(
+    rect: Rect2D,
+    ctx: ToolContext<SelectState>,
+    initialSelection: readonly SelectableId[],
+  ): void {
     if (ctx.editor.sessionMode === "preview") {
       ctx.editor.selection.clear();
       return;
     }
 
     const pointIds = this.getPointsInRect(rect, ctx);
-    ctx.editor.selection.select([...pointIds]);
+    ctx.editor.selection.select([...initialSelection, ...pointIds]);
   }
 }

--- a/apps/desktop/src/renderer/src/lib/tools/select/types.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/select/types.ts
@@ -5,6 +5,7 @@ import type { CornerHandle } from "./BoundingBox";
 import type { Behavior } from "../core/Behavior";
 import type { Select } from "./Select";
 import type { SegmentId } from "@/types/indicator";
+import type { SelectableId } from "@/types";
 
 export interface DragTarget {
   pointIds: PointId[];
@@ -15,6 +16,7 @@ export interface DragTarget {
 export interface BrushingDrag {
   startPos: Point2D;
   currentPos: Point2D;
+  initialSelection: readonly SelectableId[];
 }
 
 /** Live state of a point-translate drag, including accumulated delta for undo grouping. */

--- a/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
+++ b/apps/desktop/src/renderer/src/lib/tools/shape/Shape.test.ts
@@ -253,10 +253,13 @@ describe.each(["rectangle", "ellipse"] as const)("%s drawing lifecycle", (kind) 
       end: { x: 210, y: 120 },
     });
     const points = editor.glyphContours[0].points;
+    const selection = editor.selection.ids;
     await editor.undo();
     expect(editor.glyphContours).toHaveLength(0);
+    expect(editor.selection.ids).toEqual([]);
     await editor.redo();
     expect(editor.glyphContours[0].points).toEqual(points);
     expect(editor.glyphContours[0].closed).toBe(true);
+    expect(editor.selection.ids).toEqual(selection);
   });
 });

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.test.ts
@@ -14,6 +14,7 @@ import {
   type Unicode,
 } from "@shift/types";
 import { createWorkspaceStack, type WorkspaceStack } from "@/testing/workspaceStack";
+import type { PendingEditId } from "@/types";
 
 const createGlyph = (
   name: string,
@@ -156,6 +157,31 @@ describe("WorkspaceEditCoordinator issues save on the committed-op lane", () => 
 
     await editCoordinator.undo();
     expect(store.workspaceCell.peek()?.glyphs).toHaveLength(0);
+  });
+
+  it("publishes accepted edits and resolves their ledger identities after settling", async () => {
+    const { store, editCoordinator } = stack;
+    const accepted: PendingEditId[] = [];
+    const unsubscribe = editCoordinator.subscribeEdits((editId) => accepted.push(editId));
+
+    const editId = editCoordinator.push(createGlyph("A", 65));
+    expect(accepted).toEqual([editId]);
+
+    await editCoordinator.settled();
+    const ledgerEntryId = editCoordinator.ledgerEntryId(editId);
+    expect(ledgerEntryId).not.toBeNull();
+    if (!ledgerEntryId) throw new Error("Expected committed ledger identity");
+
+    await editCoordinator.undo(ledgerEntryId);
+    expect(store.workspaceCell.peek()?.glyphs).toHaveLength(0);
+    expect(editCoordinator.hasRedo).toBe(true);
+
+    await editCoordinator.discardRedo();
+    expect(editCoordinator.hasRedo).toBe(false);
+
+    unsubscribe();
+    editCoordinator.push(createGlyph("B", 66));
+    expect(accepted).toEqual([editId]);
   });
 
   it("groups transaction pushes into one undo entry", async () => {

--- a/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.ts
+++ b/apps/desktop/src/renderer/src/lib/workspace/WorkspaceEditCoordinator.ts
@@ -19,10 +19,17 @@ import type {
 } from "@shared/workspace/protocol";
 import { batch, signal, type Signal, type WritableSignal } from "@/lib/signals/signal";
 import type { FontStore } from "@/lib/model/FontStore";
-import type { PendingEditId, WorkspaceApplyStatus, WorkspaceEdit } from "@/types";
+import type {
+  PendingEditId,
+  WorkspaceApplyStatus,
+  WorkspaceEdit,
+  WorkspaceEditListener,
+} from "@/types";
 import type { FontSessionClient } from "./FontSessionClient";
 
 export type { WorkspaceApplyStatus } from "@/types";
+
+const MAX_LEDGER_ENTRY_IDS = 100;
 
 /**
  * Tracks pending renderer edits until the utility workspace confirms them.
@@ -45,6 +52,9 @@ export class WorkspaceEditCoordinator {
   readonly #store: FontStore;
   readonly #settledCell: WritableSignal<boolean>;
   readonly #applyStatus: WritableSignal<WorkspaceApplyStatus>;
+  readonly #editListeners = new Set<WorkspaceEditListener>();
+  readonly #ledgerEntryIds = new Map<PendingEditId, LedgerEntryId>();
+  readonly #redoEntryIds: LedgerEntryId[] = [];
 
   #chain: Promise<unknown> = Promise.resolve();
   #busy = 0;
@@ -82,6 +92,32 @@ export class WorkspaceEditCoordinator {
    */
   get applyStatusCell(): Signal<WorkspaceApplyStatus> {
     return this.#applyStatus;
+  }
+
+  /** Whether coordinator-owned document replay currently has a redo branch. */
+  get hasRedo(): boolean {
+    return this.#redoEntryIds.length > 0 && this.#applyStatus.peek() === "idle";
+  }
+
+  /**
+   * Observes edits synchronously as they enter the serialized workspace lane.
+   *
+   * @param listener - Receives the renderer-local identity once per accepted operation.
+   * @returns A function that permanently removes this listener.
+   */
+  subscribeEdits(listener: WorkspaceEditListener): () => void {
+    this.#editListeners.add(listener);
+    return () => this.#editListeners.delete(listener);
+  }
+
+  /**
+   * Resolves a settled renderer edit to its stable document-ledger identity.
+   *
+   * @param editId - Renderer-local identity returned when the edit was accepted.
+   * @returns The ledger identity, or null when the edit is pending or failed.
+   */
+  ledgerEntryId(editId: PendingEditId): LedgerEntryId | null {
+    return this.#ledgerEntryIds.get(editId) ?? null;
   }
 
   /** Accepts one intent and returns its renderer-local pending identity. */
@@ -184,7 +220,10 @@ export class WorkspaceEditCoordinator {
   undo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     return this.#withFlush(async () => {
       const applied = await this.#session.undo(entryId);
-      if (applied) await this.#applyChange(applied, null);
+      if (applied) {
+        await this.#applyChange(applied, null);
+        if (applied.ledgerEntryId) this.#redoEntryIds.push(applied.ledgerEntryId);
+      }
       return applied;
     });
   }
@@ -274,14 +313,25 @@ export class WorkspaceEditCoordinator {
   redo(entryId?: LedgerEntryId): Promise<AppliedChange | null> {
     return this.#withFlush(async () => {
       const applied = await this.#session.redo(entryId);
-      if (applied) await this.#applyChange(applied, null);
+      if (applied) {
+        await this.#applyChange(applied, null);
+        const expected = this.#redoEntryIds.at(-1);
+        if (expected === applied.ledgerEntryId) {
+          this.#redoEntryIds.pop();
+        } else {
+          this.#redoEntryIds.length = 0;
+        }
+      }
       return applied;
     });
   }
 
   /** Permanently removes the current document redo branch after pending operations flush. */
   discardRedo(): Promise<void> {
-    return this.#withFlush(() => this.#session.discardRedo());
+    return this.#withFlush(async () => {
+      await this.#session.discardRedo();
+      this.#redoEntryIds.length = 0;
+    });
   }
 
   /** Reads document state behind every queued and in-flight edit. */
@@ -353,6 +403,7 @@ export class WorkspaceEditCoordinator {
         this.#applyStatus.set("queued");
       }
     });
+    for (const listener of this.#editListeners) listener(edit.id);
     return edit;
   }
 
@@ -365,6 +416,16 @@ export class WorkspaceEditCoordinator {
   async #sendEdit(edit: WorkspaceEdit): Promise<AppliedChange> {
     this.#applyStatus.set("applying");
     const applied = await this.#session.apply(edit.intents, edit.label);
+    const ledgerEntryId = applied.ledgerEntryId;
+    if (!ledgerEntryId) throw new Error("workspace edit did not create a document ledger entry");
+
+    this.#redoEntryIds.length = 0;
+    this.#ledgerEntryIds.set(edit.id, ledgerEntryId);
+    if (this.#ledgerEntryIds.size > MAX_LEDGER_ENTRY_IDS) {
+      const oldestEditId = this.#ledgerEntryIds.keys().next().value;
+      if (oldestEditId !== undefined) this.#ledgerEntryIds.delete(oldestEditId);
+    }
+
     await this.#applyChange(applied, edit.id);
     return applied;
   }

--- a/apps/desktop/src/renderer/src/types/history.ts
+++ b/apps/desktop/src/renderer/src/types/history.ts
@@ -1,0 +1,27 @@
+import type { LedgerEntryId } from "@shift/types";
+import type { PendingEditId } from "./editing";
+import type { SelectableId } from "./object";
+
+/** One reversible contiguous difference between two ordered sequences. */
+export interface SequenceDiff<T> {
+  readonly start: number;
+  readonly removed: readonly T[];
+  readonly inserted: readonly T[];
+}
+
+/** Observes one complete ordered selection replacement. */
+export type SelectionListener = (
+  before: readonly SelectableId[],
+  after: readonly SelectableId[],
+) => void;
+
+/** Reversible changes to explicitly undoable renderer-owned editor properties. */
+export interface EditorDiff {
+  readonly selection?: SequenceDiff<SelectableId>;
+}
+
+/** One user action combining optional document replay with renderer-owned changes. */
+export interface HistoryItem {
+  readonly document: PendingEditId | LedgerEntryId | null;
+  readonly editor: EditorDiff | null;
+}

--- a/apps/desktop/src/renderer/src/types/index.ts
+++ b/apps/desktop/src/renderer/src/types/index.ts
@@ -17,6 +17,7 @@ export type {
 } from "./glyphCatalog";
 export type { EditingId, PendingEditId } from "./editing";
 export type { FontOptions, FontStoreOptions } from "./font";
+export type { EditorDiff, HistoryItem, SelectionListener, SequenceDiff } from "./history";
 export type { GlyphGeometrySelection, GlyphOptions, GlyphReader } from "./glyph";
 export type {
   GlyphAtlasGlyph,
@@ -59,7 +60,7 @@ export type {
   PositionSnapProvider,
   PositionTargets,
 } from "./positionEdit";
-export type { WorkspaceApplyStatus, WorkspaceEdit } from "./workspace";
+export type { WorkspaceApplyStatus, WorkspaceEdit, WorkspaceEditListener } from "./workspace";
 
 export interface GlyphObjectSegment {
   readonly id: SegmentId;

--- a/apps/desktop/src/renderer/src/types/workspace.ts
+++ b/apps/desktop/src/renderer/src/types/workspace.ts
@@ -8,4 +8,7 @@ export interface WorkspaceEdit {
   readonly label?: string;
 }
 
+/** Observes one renderer edit when it enters the serialized workspace lane. */
+export type WorkspaceEditListener = (editId: PendingEditId) => void;
+
 export type WorkspaceApplyStatus = "idle" | "queued" | "applying";

--- a/apps/desktop/src/renderer/src/views/Editor.tsx
+++ b/apps/desktop/src/renderer/src/views/Editor.tsx
@@ -61,7 +61,7 @@ export const Editor = () => {
 
     return () => {
       editor.toolManager.reset();
-      editor.selection.clear();
+      editor.history.reset();
       editor.hover.clear();
       if (editor.editing.has(nodeId)) editor.editing.clear();
       editor.scene.deleteNode(nodeId);


### PR DESCRIPTION
## Summary

- add renderer-owned `EditorHistory` with minimal ordered `SequenceDiff` values for selection
- interleave editor diffs with stable Rust ledger references without persisting selection or marking the document dirty
- capture clicks, keys, marquee, drags, Delete, Cut, Paste, Duplicate, Pen, Shape, and boolean operations as complete user actions
- reset renderer history at glyph-route boundaries and invalidate document redo only when a selection-only branch requires it
- add real-editor and Playwright coverage for selection-only, compound, canceled, and branched history

## Stack

Depends on #367.

## Issue

Closes #366

Related: #113, #114

## Testing

Passed:

- `pnpm test` — 88 desktop files / 869 desktop tests plus all package and native bridge suites
- `pnpm typecheck`
- `pnpm lint:check`
- `pnpm format:check`
- `python3 scripts/check-invariants.py`
- `pnpm test:e2e:visual e2e/selection-history.spec.ts` — 2 passed
- `pnpm test:e2e:visual e2e/deletion.spec.ts --grep 'Delete fits'` — 1 passed

`python3 scripts/context-drift-check.py` completed link checks but reports 9 pre-existing review-date warnings in unrelated documentation.

## Evidence

`e2e/selection-history.spec.ts` attaches screenshots for:

- Shift-click selection and its undone state
- before selection+drag
- selected and dragged
- selection+drag undone
- selection+drag redone

The tests also assert exact selected IDs and point positions after Undo and Redo; the focused deletion E2E asserts Delete restores both the exact outline and its prior selection in one step.
